### PR TITLE
feat(BE): 비밀번호 찾기 및 재설정 API 구현 / fix(BE): 회원가입 시 birth NOT NULL 오류 수정

### DIFF
--- a/backend/accounts/serializers.py
+++ b/backend/accounts/serializers.py
@@ -1,6 +1,7 @@
 from django.contrib.auth import get_user_model
 from rest_framework import serializers
 from dj_rest_auth.registration.serializers import RegisterSerializer
+from django.contrib.auth.password_validation import validate_password
 
 User = get_user_model()
 
@@ -29,3 +30,38 @@ class CustomRegisterSerializer(RegisterSerializer):
         user.birth = self.validated_data.get("birth")
         user.save()
         return user
+
+
+class PasswordResetSerializer(serializers.Serializer):
+    email = serializers.EmailField()
+
+    def validate_email(self, value):
+        return value
+
+
+class UserPasswordResetConfirmSerializer(serializers.ModelSerializer):
+    new_password = serializers.CharField(write_only=True)
+    new_password2 = serializers.CharField(write_only=True)
+
+    class Meta:
+        model = User
+        # User 모델에서 비밀번호만 처리 
+        fields = ("new_password", "new_password2")
+
+    def validate(self, attrs):
+        pw1 = attrs.get("new_password")
+        pw2 = attrs.get("new_password2")
+
+        if pw1 != pw2:
+            raise serializers.ValidationError(
+                {"new_password2": "비밀번호가 일치하지 않습니다."}
+            )
+
+        validate_password(pw1, self.instance)
+        return attrs
+
+    def update(self, instance, validated_data):
+        new_password = validated_data.get['new_password']
+        instance.set_password(new_password)
+        instance.save()
+        return instance

--- a/backend/accounts/serializers.py
+++ b/backend/accounts/serializers.py
@@ -36,6 +36,8 @@ class PasswordResetSerializer(serializers.Serializer):
     email = serializers.EmailField()
 
     def validate_email(self, value):
+        if not User.objects.filter(email=value).exists():
+            raise serializers.ValidationError("등록되지 않은 이메일입니다.")
         return value
 
 

--- a/backend/accounts/serializers.py
+++ b/backend/accounts/serializers.py
@@ -2,6 +2,9 @@ from django.contrib.auth import get_user_model
 from rest_framework import serializers
 from dj_rest_auth.registration.serializers import RegisterSerializer
 from django.contrib.auth.password_validation import validate_password
+from allauth.account.adapter import get_adapter
+from allauth.account.utils import setup_user_email
+
 
 User = get_user_model()
 
@@ -15,20 +18,25 @@ class CustomRegisterSerializer(RegisterSerializer):
     birth = serializers.DateField(required=True)
 
     def get_cleaned_data(self):
-        cleaned_data = super().get_cleaned_data()
-        cleaned_data.update(
-            {
-                "nickname": self.validated_data.get("nickname", ""),
-                "birth": self.validated_data.get("birth", None),
-            }
-        )
-        return cleaned_data
+        data = super().get_cleaned_data()
+        data["nickname"] = self.validated_data.get("nickname")
+        data["birth"] = self.validated_data.get("birth")
+        return data
 
     def save(self, request):
-        user = super().save(request)
-        user.nickname = self.validated_data.get("nickname")
-        user.birth = self.validated_data.get("birth")
+        adapter = get_adapter()
+        user = adapter.new_user(request)
+        # allauth가 기본 필드(username/email/password 등) 세팅하도록 하되
+        # DB 저장은 아직 하지 않도록(commit=False)
+        self.cleaned_data = self.get_cleaned_data()
+        adapter.save_user(request, user, self, commit=False)
+        # 여기서 NOT NULL 커스텀 필드 먼저 세팅
+        user.nickname = self.cleaned_data.get("nickname")
+        user.birth = self.cleaned_data.get("birth")
+        # 이제 저장하면 NOT NULL 위반 없음
         user.save()
+        # 이메일 관련 설정(올어스 내부 로직)
+        setup_user_email(request, user, [])
         return user
 
 

--- a/backend/accounts/urls.py
+++ b/backend/accounts/urls.py
@@ -1,4 +1,7 @@
 from django,urls import path
 from . import views
 
-urlpatterns = []
+urlpatterns = [
+    path('find_password/', views.find_password),
+    path('reset_password/', views.reset_password),
+]

--- a/backend/accounts/views.py
+++ b/backend/accounts/views.py
@@ -1,3 +1,107 @@
 from django.shortcuts import render
+from django.conf import settings
+from django.contrib.auth import get_user_model
+from django.contrib.auth.tokens import default_token_generator
+from django.core.mail import send_mail
+from django.utils.encoding import force_bytes, force_str
+from django.utils.http import urlsafe_base64_encode, urlsafe_base64_decode
 
-# Create your views here.
+from rest_framework.decorators import api_view, permission_classes
+from rest_framework.permissions import AllowAny
+from rest_framework.response import Response
+from rest_framework import status
+
+from .serializers import (
+    PasswordResetRequestSerializer,
+    UserPasswordResetConfirmSerializer,
+)
+
+User = get_user_model()
+
+# 비밀번호 잃어버렸을 때, 이메일로 재설정 연결 
+@api_view(['POST'])
+@permission_classes([AllowAny])
+def find_password(request):
+    serializer = PasswordResetRequestSerializer(data=request.data)
+    serializer.is_valid(raise_exception=True)
+
+    email = serializer.validated_data["email"]
+    try:
+        user = User.objects.get(email=email)
+    except User.DoesNotExist:
+        return Response(
+            {"detail": "비밀번호 재설정 메일이 발송되었다면, 입력하신 이메일에서 확인하실 수 있습니다."},
+            status=status.HTTP_200_OK,
+        )
+    # uid, token 생성
+    uid = urlsafe_base64_encode(force_bytes(user.pk))
+    token = default_token_generator.make_token(user)
+
+    # 프론트 비밀번호 재설정 페이지 URL (Vue 라우트)
+    frontend_base_url = getattr(settings, "FRONTEND_BASE_URL", "http://localhost:5173")
+    reset_url = f"{frontend_base_url}/reset-password/{uid}/{token}"
+
+    subject = "[모아톤] 비밀번호 재설정 안내"
+    message = (
+        f"{user.nickname}님, 안녕하세요.\n\n"
+        f"아래 링크를 클릭하여 비밀번호를 재설정해 주세요.\n\n"
+        f"{reset_url}\n\n"
+        f"만약 비밀번호 재설정을 요청하지 않으셨다면 이 메일은 무시하셔도 됩니다."
+    )
+    from_email = getattr(settings, "DEFAULT_FROM_EMAIL", "no-reply@moathon.com")
+
+    send_mail(
+        subject,
+        message,
+        from_email,
+        [email],
+        fail_silently=False,
+    )
+
+    return Response(
+        {"detail": "비밀번호 재설정 메일이 발송되었다면, 입력하신 이메일에서 확인하실 수 있습니다."},
+        status=status.HTTP_200_OK,
+    )
+
+# 비밀번호 재설정
+@api_view(['POST'])
+@permission_classes([AllowAny])
+def reset_password(request):
+    uidb64 = request.data.get("uid")
+    token = request.data.get("token")
+
+    if not uidb64 or not token:
+        return Response(
+            {"detail": "잘못된 요청입니다."},
+            status=status.HTTP_400_BAD_REQUEST,
+        )
+    # uid 디코딩 → User 조회
+    try:
+        uid = force_str(urlsafe_base64_decode(uidb64))
+        user = User.objects.get(pk=uid)
+    except (User.DoesNotExist, ValueError, TypeError, OverflowError):
+        return Response(
+            {"detail": "유효하지 않은 사용자입니다."},
+            status=status.HTTP_400_BAD_REQUEST,
+        )
+
+    # token 검증
+    if not default_token_generator.check_token(user, token):
+        return Response(
+            {"detail": "토큰이 유효하지 않거나 만료되었습니다."},
+            status=status.HTTP_400_BAD_REQUEST,
+        )
+
+    # 비밀번호 검증 + 저장 
+    serializer = UserPasswordResetConfirmSerializer(
+        instance=user,
+        data=request.data,
+        partial=True,  # 비밀번호 필드만 업데이트
+    )
+    serializer.is_valid(raise_exception=True)
+    serializer.save()  # 내부에서 set_password 호출
+
+    return Response(
+        {"detail": "비밀번호가 성공적으로 변경되었습니다."},
+        status=status.HTTP_200_OK,
+    )

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -7,3 +7,4 @@ django-allauth==64.0.0
 django-cors-headers==4.9.0
 django-environ
 Pillow==12.0.0
+drf-spectacular==0.29.0


### PR DESCRIPTION
## 💡 개요 (Overview)
> 비밀번호 잃어버렸을 시, 사용자는 이메일로 전달된 링크로 비밀번호 변경 가능
> 회원가입 시 birth NOT NULLL 오류 해결  

## 📃 작업 내용 (Details)
- [ ] 이메일 기반 비밀번호 재설정 요청(find_password) 엔드포인트 추가
- [ ] uid/token을 활용한 비밀번호 재설정(reset_password) 로직 구현
- [ ] User 기반 Serializer에서 set_password 및 password validator 적용
- [ ] dj-rest-auth RegisterSerializer 저장 순서 문제로 발생한 오류 해결

## 🔗 관련 이슈 (Links)
- closes #32 #31 

## 📚 테스트 (Test)
- [x] 로컬 환경에서 기능 테스트 완료