### PR TITLE
feat(FE): 온보딩 페이지 구현

### DIFF
--- a/frontend/src/components/user/ProfileForm.vue
+++ b/frontend/src/components/user/ProfileForm.vue
@@ -1,0 +1,116 @@
+<template>
+  <div class="onboarding-container">
+    <form @submit.prevent="submitForm" enctype="multipart/form-data">
+      <div class="form-group">
+        <label for="profile_image">프로필 사진</label>
+        <input type="file" id="profile_image" accept="image/*" @change="onFileChange" />
+      </div>
+
+      <div class="form-group">
+        <label for="gender">성별<span class="required">*</span></label>
+        <select id="gender" v-model="gender" required>
+          <option disabled value="">성별을 선택해주세요</option>
+          <option value="0">남성</option>
+          <option value="1">여성</option>
+        </select>
+      </div>
+
+      <div class="form-group">
+        <label for="credit_score">신용점수<span class="required">*</span></label>
+        <input type="number" id="credit_score" v-model.number="credit_score" placeholder="예: 850" required min="0"
+          max="1000" />
+      </div>
+
+      <div class="form-group">
+        <label for="assets">자산 (만원 단위)<span class="required">*</span></label>
+        <input type="number" id="assets" v-model.number="assets" placeholder="예: 1000" required min="0" />
+      </div>
+
+      <div class="form-group">
+        <label for="salary">연봉 (만원 단위)<span class="required">*</span></label>
+        <input type="number" id="salary" v-model.number="salary" placeholder="예: 3000" required min="0" />
+      </div>
+
+      <div class="form-group">
+        <label for="average_monthly_spend">평균 월 지출 (만원 단위)<span class="required">*</span></label>
+        <input type="number" id="average_monthly_spend" v-model.number="average_monthly_spend" placeholder="예: 100"
+          required min="0" />
+      </div>
+
+      <div class="form-group">
+        <label for="tender">투자 성향<span class="required">*</span></label>
+        <select id="tender" v-model="tender" required>
+          <option disabled value="">투자 성향을 선택해주세요</option>
+          <option value="1">매우 보수적 (안정형)</option>
+          <option value="2">보수적 (안정추구형)</option>
+          <option value="3">보통 (위험중립형)</option>
+          <option value="4">공격적 (적극투자형)</option>
+          <option value="5">매우 공격적 (공격투자형)</option>
+        </select>
+      </div>
+
+      <button type="submit" class="submit-btn">저장하기</button>
+    </form>
+  </div>
+</template>
+
+<script setup>
+import { ref } from 'vue';
+import { useAccountStore } from '@/stores/accounts';
+
+const emit = defineEmits(['success'])
+
+const accountStore = useAccountStore()
+
+const profile_image = ref(null)
+const gender = ref('')
+const credit_score = ref(null)
+const assets = ref(null)
+const salary = ref(null)
+const average_monthly_spend = ref(null)
+const tender = ref('')
+
+const onFileChange = (event) => {
+  const files = event.target.files;
+  if (files.length > 0) {
+    profile_image.value = files[0];
+  } else {
+    profile_image.value = null;
+  }
+};
+
+const submitForm = async function () {
+  if (!gender.value || !credit_score.value || !assets.value ||
+    !salary.value || !average_monthly_spend.value || !tender.value) {
+    alert('모든 필수 항목을 입력해주세요.');
+    return;
+  }
+
+  const formData = new FormData();
+
+  formData.append('gender', gender.value);
+  formData.append('credit_score', credit_score.value);
+  formData.append('assets', assets.value);
+  formData.append('salary', salary.value);
+  formData.append('average_monthly_spend', average_monthly_spend.value);
+  formData.append('tender', tender.value);
+
+  if (profile_image.value) {
+    formData.append('profile_image', profile_image.value);
+  }
+
+  try {
+    await accountStore.updateProfile(formData);
+    emit('success')
+  } catch (error) {
+    alert('저장에 실패했습니다.')
+  }
+}
+</script>
+
+<style scoped>
+.required {
+  color: red;
+  margin-left: 2px;
+}
+</style>

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -1,4 +1,5 @@
 import LoginView from '@/views/auth/LoginView.vue'
+import OnboardingView from '@/views/auth/OnboardingView.vue'
 import SignupView from '@/views/auth/SignupView.vue'
 import HomeView from '@/views/HomeView.vue'
 import MoathonCreateView from '@/views/moathon/MoathonCreateView.vue'
@@ -24,6 +25,11 @@ const router = createRouter({
       path: '/signup',
       name: 'signup',
       component: SignupView,
+    },
+    {
+      path: '/onboarding',
+      name: 'onboarding',
+      component: OnboardingView,
     },
     {
       path: '/moathons',

--- a/frontend/src/stores/accounts.js
+++ b/frontend/src/stores/accounts.js
@@ -1,7 +1,7 @@
 import { ref, computed } from 'vue'
 import { defineStore } from 'pinia'
 import axios from 'axios'
-import { useRoute, useRouter } from 'vue-router'
+import { useRouter } from 'vue-router'
 
 export const useAccountStore = defineStore('account', () => {
   const router = useRouter()
@@ -61,12 +61,29 @@ export const useAccountStore = defineStore('account', () => {
     return token.value ? true : false
   })
 
+  const updateProfile = function (payload) {
+    axios({
+      method: 'patch',
+      url: `${API_URL}/accounts/user/`,
+      data: payload,
+      headers: {
+        Authorization: `Token ${token.value}`,
+        'Content-Type': 'multipart/form-data'
+      }
+    })
+      .then(res => {
+        console.log('프로필 정보가 저장되었습니다.', res.data)
+      })
+      .catch(err => console.log(err))
+  }
+
   return { 
     API_URL,
     token,
     signUp,
     logIn,
     logOut,
-    isAuthenticated
+    isAuthenticated,
+    updateProfile,
    }
 })

--- a/frontend/src/stores/accounts.js
+++ b/frontend/src/stores/accounts.js
@@ -22,6 +22,7 @@ export const useAccountStore = defineStore('account', () => {
         console.log('회원가입이 완료되었습니다.')
         const password = password1
         logIn({ username, email, password })
+        router.replace({ name: 'onboarding' })
       })
       .catch(err => console.log(err))
   }

--- a/frontend/src/views/auth/OnboardingView.vue
+++ b/frontend/src/views/auth/OnboardingView.vue
@@ -1,0 +1,24 @@
+<template>
+  <div>
+    <h1>프로필 정보 입력</h1>
+    <p>입력한 정보는 고객님을 위한 맞춤 예/적금 상품 추천에 사용됩니다.</p>
+
+    <ProfileForm @success="goHome" />
+  </div>
+</template>
+
+<script setup>
+  import ProfileForm from '@/components/user/ProfileForm.vue';
+  import { useRouter } from 'vue-router';
+
+  const router = useRouter()
+
+  const goHome = function () {
+    alert('환영합니다! 가입이 완료되었습니다.')
+    router.push({ name: 'home' })
+  }
+</script>
+
+<style scoped>
+
+</style>


### PR DESCRIPTION
## 💡 개요 (Overview)
> 회원가입 후 프로필 정보를 입력하기 위한 온보딩 페이지를 구현합니다. 해당 프로필 정보는 추후 예/적금 상품 추천에 사용됩니다.

## 📃 작업 내용 (Details)
- [ ] `stores/accounts.js` 에 updateProfile 액션 구현
- [ ] `router/index.js` 에 `/onboarding` URL 생성
- [ ] `components/user/ProfileForm.vue` 프로필 정보 입력을 위한 폼 컴포넌트 생성
- [ ] `views/auth/OnboardingView.vue`에 ProfileForm 컴포넌트 연결


## 🔗 관련 이슈 (Links)
- Closes #36

## 🎸 기타 사항 & 트러블 슈팅 (Notes)
사용자 프로필 입력 관련 백엔드 API가 없어서 임의의 주소(`/accounts/user/`)로 PATCH 요청을 작성해두었습니다.
