### PR TITLE
feat(products): 금융 상품 목록/상세 조회 API 구현

### DIFF
--- a/backend/challenges/serializers.py
+++ b/backend/challenges/serializers.py
@@ -1,6 +1,6 @@
 from rest_framework import serializers
 from .models import Moathon
-from products.models import ProductOption
+from products.models import ProductOptionSimpleSerializer
 from products.serializers import ProductOptionSerializer
 from datetime import date
 
@@ -10,8 +10,8 @@ class MoathonDetailSerializer(serializers.ModelSerializer):
     profile_image = serializers.ImageField(source='user.profile_image', read_only=True)
     # 뱃지 로직이 있다면 source='user.badge' 등으로 추가
     
-    # Nested Serializer: ProductOption의 상세 정보를 한 번에 보여줌
-    product_option = ProductOptionSerializer(read_only=True)
+    # Nested Serializer: ProductOptionSimpleSerializer의 상세 정보를 한 번에 보여줌
+    product_option = ProductOptionSimpleSerializer(read_only=True)
     progress_rate = serializers.SerializerMethodField()
 
     class Meta:

--- a/backend/challenges/serializers.py
+++ b/backend/challenges/serializers.py
@@ -1,7 +1,7 @@
 from rest_framework import serializers
 from .models import Moathon
-from products.models import ProductOptionSimpleSerializer
-from products.serializers import ProductOptionSerializer
+from products.models import ProductOption
+from products.serializers import ProductOptionSimpleSerializer
 from datetime import date
 
 # 단일 모아톤 조회
@@ -10,7 +10,6 @@ class MoathonDetailSerializer(serializers.ModelSerializer):
     profile_image = serializers.ImageField(source='user.profile_image', read_only=True)
     # 뱃지 로직이 있다면 source='user.badge' 등으로 추가
     
-    # Nested Serializer: ProductOptionSimpleSerializer의 상세 정보를 한 번에 보여줌
     product_option = ProductOptionSimpleSerializer(read_only=True)
     progress_rate = serializers.SerializerMethodField()
 

--- a/backend/products/serializers.py
+++ b/backend/products/serializers.py
@@ -1,16 +1,17 @@
 from rest_framework import serializers
 from .models import Product, ProductOption
 
-class ProductOptionSerializer(serializers.ModelSerializer):
-    fin_prdt_nm = serializers.CharField(source='product.fin_prdt_nm', read_only=True)
+# 모아톤 상세 페이지에 사용할 금융 상품 정보
+class ProductOptionSimpleSerializer(serializers.ModelSerializer):
+    product_name = serializers.CharField(source='product.fin_prdt_nm', read_only=True)
     product_type = serializers.CharField(source='product.product_type', read_only=True)
-    kor_co_nm = serializers.CharField(source='product.bank.kor_co_nm', read_only=True)
+    bank_name = serializers.CharField(source='product.bank.kor_co_nm', read_only=True)
 
     class Meta:
         model = ProductOption
         fields = [
             'id',
-            'fin_prdt_nm',   # 상품명
-            'kor_co_nm',     # 은행명
+            'product_name',   # 상품명
+            'bank_name',     # 은행명
             'product_type',  # 예금/적금 구분
         ]

--- a/backend/products/serializers.py
+++ b/backend/products/serializers.py
@@ -21,6 +21,43 @@ class ProductListSerializer(serializers.ModelSerializer):
     class ProductOptionSerializer(serializers.ModelSerializer):
         class Meta:
             model = ProductOption
+            fields = [
+                'id', 
+                'save_trm', 
+                'intr_rate', 
+                'intr_rate2'
+            ]
+
+    options = ProductOptionSerializer(many=True, read_only=True)
+    bank_name = serializers.CharField(source='bank.kor_co_nm', read_only=True)
+    max_rate = serializers.SerializerMethodField()
+
+    class Meta:
+        model = Product
+        fields = [
+            'id', 
+            'dcls_month',
+            'bank_name', 
+            'product_type', 
+            'fin_prdt_nm',
+            'join_way',
+            'options',
+            'max_rate',
+        ]
+    
+    # 해당 상품의 옵션 중 가장 높은 우대금리를 계산해서 반환
+    def get_max_rate(self, obj):
+        options = obj.options.all()
+        if not options:
+            return None
+        rates = [opt.intr_rate2 for opt in options if opt.intr_rate2 is not None]
+        return max(rates) if rates else None
+
+# 금융 상품 상세 조회
+class ProductDetailSerializer(serializers.ModelSerializer):
+    class ProductOptionSerializer(serializers.ModelSerializer):
+        class Meta:
+            model = ProductOption
             fields = '__all__'
 
     options = ProductOptionSerializer(many=True, read_only=True)

--- a/backend/products/serializers.py
+++ b/backend/products/serializers.py
@@ -15,3 +15,17 @@ class ProductOptionSimpleSerializer(serializers.ModelSerializer):
             'bank_name',     # 은행명
             'product_type',  # 예금/적금 구분
         ]
+        
+# 금융 상품 전체 조회
+class ProductListSerializer(serializers.ModelSerializer):
+    class ProductOptionSerializer(serializers.ModelSerializer):
+        class Meta:
+            model = ProductOption
+            fields = '__all__'
+
+    options = ProductOptionSerializer(many=True, read_only=True)
+    bank_name = serializers.CharField(source='bank.kor_co_nm', read_only=True)
+
+    class Meta:
+        model = Product
+        fields = '__all__'

--- a/backend/products/urls.py
+++ b/backend/products/urls.py
@@ -3,4 +3,5 @@ from . import views
 
 urlpatterns = [
     path('', views.product_list),
+    path('<int:product_id>/', views.product_detail),
 ]

--- a/backend/products/urls.py
+++ b/backend/products/urls.py
@@ -1,3 +1,6 @@
 from django.urls import path
+from . import views
 
-urlpatterns = []
+urlpatterns = [
+    path('', views.product_list),
+]

--- a/backend/products/views.py
+++ b/backend/products/views.py
@@ -1,3 +1,33 @@
-from django.shortcuts import render
+from rest_framework.decorators import api_view, permission_classes
+from rest_framework.permissions import AllowAny, IsAuthenticated
+from rest_framework.response import Response
 
-# Create your views here.
+from django.shortcuts import render, get_object_or_404
+from .models import Product, ProductOption
+from .serializers import ProductListSerializer
+
+@api_view(['GET'])
+@permission_classes([AllowAny])
+def product_list(request):
+    """
+    전체 금융 상품 조회 API
+    
+    GET /products/
+    """
+    products = Product.objects.all()
+
+    bank_name = request.query_params.get('bank')       # 은행명 (UI: 은행 선택)
+    product_type = request.query_params.get('type')    # 상품 유형 (UI: 예금/적금 탭)
+    save_trm = request.query_params.get('period')      # 예치 기간 (UI: 예치기간)
+
+    if product_type:
+        products = products.filter(product_type=product_type)
+
+    if bank_name and bank_name != '전체':
+        products = products.filter(bank__kor_co_nm=bank_name)
+
+    if save_trm and save_trm != '전체기간':
+        products = products.filter(options__save_trm=save_trm).distinct()
+    
+    serializer = ProductListSerializer(products, many=True)
+    return Response(serializer.data)

--- a/backend/products/views.py
+++ b/backend/products/views.py
@@ -1,6 +1,7 @@
 from rest_framework.decorators import api_view, permission_classes
 from rest_framework.permissions import AllowAny, IsAuthenticated
 from rest_framework.response import Response
+from rest_framework.pagination import PageNumberPagination
 
 from django.shortcuts import render, get_object_or_404
 from .models import Product, ProductOption
@@ -14,7 +15,7 @@ def product_list(request):
     
     GET /products/
     """
-    products = Product.objects.all()
+    products = Product.objects.filter(is_active=True)
 
     bank_name = request.query_params.get('bank')       # 은행명 (UI: 은행 선택)
     product_type = request.query_params.get('type')    # 상품 유형 (UI: 예금/적금 탭)
@@ -29,5 +30,25 @@ def product_list(request):
     if save_trm and save_trm != '전체기간':
         products = products.filter(options__save_trm=save_trm).distinct()
     
+    paginator = PageNumberPagination()
+    paginator.page_size = 50
+    result_page = paginator.paginate_queryset(products, request)
+
+    if result_page is not None:
+        serializer = ProductListSerializer(result_page, many=True)
+        return paginator.get_paginated_response(serializer.data)
+    
     serializer = ProductListSerializer(products, many=True)
+    return Response(serializer.data)
+
+@api_view(['GET'])
+@permission_classes([AllowAny])
+def product_detail(request, product_id):
+    """
+    금융 상품 상세 조회 API
+    
+    GET /products/<int:product_id>/
+    """
+    product = get_object_or_404(Product, pk=product_id)
+    serializer = ProductListSerializer(product)
     return Response(serializer.data)

--- a/backend/products/views.py
+++ b/backend/products/views.py
@@ -2,11 +2,19 @@ from rest_framework.decorators import api_view, permission_classes
 from rest_framework.permissions import AllowAny, IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.pagination import PageNumberPagination
+from drf_spectacular.utils import extend_schema, OpenApiParameter
 
 from django.shortcuts import render, get_object_or_404
 from .models import Product, ProductOption
 from .serializers import ProductListSerializer
 
+@extend_schema(
+    parameters=[
+        OpenApiParameter(name='bank', description='은행명 (예: 우리은행)', required=False, type=str),
+        OpenApiParameter(name='type', description='상품 유형 (예: DEPOSIT, SAVING)', required=False, type=str),
+        OpenApiParameter(name='period', description='예치 기간 (예: 12)', required=False, type=int),
+    ]
+)
 @api_view(['GET'])
 @permission_classes([AllowAny])
 def product_list(request):


### PR DESCRIPTION
## 💡 개요 (Overview)
금융 상품(예금/적금)을 사용자가 조회하고 필터링할 수 있는 API를 구현했습니다.

## 📃 작업 내용 (Details)
- ProductListSerializer: 목록 조회용 경량화 Serializer 구현
    - options 포함 (금리, 기간 정보)
    - bank_name (은행명 평탄화), join_way (가입방법), max_rate (최고 우대금리 계산) 필드 추가
- ProductDetailSerializer: 상세 조회용 Serializer 구현 (모든 필드 및 옵션 포함)

- GET /products/: 전체 상품 목록 조회
    - is_active=True인 상품만 필터링
    - Query Params 필터링 구현: bank(은행명), type(예금/적금), period(가입기간)
- GET /products/<id>/: 상품 상세 정보 조회

## 🔗 관련 이슈 (Links)
- Closes #58 

## 📸 스크린샷 (Screenshots)
|목록 조회(전체)| 목록 조회(필터링) | 상세 조회|
| -- | -- | -- |
|<img width="1789" height="850" alt="image" src="https://github.com/user-attachments/assets/89091e5a-0627-4878-b3b2-d8187f0bbae3" /> |<img width="1200" height="864" alt="image" src="https://github.com/user-attachments/assets/7ceaecc0-7178-4188-81a1-535b095b490f" /> | <img width="1799" height="802" alt="image" src="https://github.com/user-attachments/assets/0cfaae5a-e057-4efc-97a3-14206298c95b" />|

## 📚 테스트 (Test)
- [ ] 전체 조회: http://localhost:8000/products/
- [ ] 필터링: http://localhost:8000/products/?bank=우리은행&period=12
- [ ] 상세 조회: http://localhost:8000/products/1/