### PR TITLE
Feat/fe moathon card

### DIFF
--- a/backend/challenges/views.py
+++ b/backend/challenges/views.py
@@ -26,7 +26,7 @@ def moathon_list(request):
         moathons = Moathon.objects.all().order_by('-id')
         
         paginator = PageNumberPagination()
-        paginator.page_size = 50
+        paginator.page_size = 24
         result_page = paginator.paginate_queryset(moathons, request)
 
         serializer = MoathonListSerializer(result_page, many=True)

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -54,7 +54,6 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -1638,7 +1637,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -2667,7 +2665,6 @@
       "integrity": "sha512-ITcnkFeR3+fI8P1wMgItjGrR10170d8auB4EpMLPqmx6uxElH3a/hHGQabSHKdqd4FXWO1nFIp9rRn7JQ34ACQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.5.0",
@@ -2886,7 +2883,6 @@
       "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.25.tgz",
       "integrity": "sha512-YLVdgv2K13WJ6n+kD5owehKtEXwdwXuj2TTyJMsO7pSeKw2bfRNZGjhB7YzrpbMYj5b5QsUebHpOqR3R3ziy/g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vue/compiler-dom": "3.5.25",
         "@vue/compiler-sfc": "3.5.25",

--- a/frontend/src/components/common/Navbar.vue
+++ b/frontend/src/components/common/Navbar.vue
@@ -22,7 +22,7 @@
           </template>
           
           <template v-else>
-            <RouterLink class="nav-link" :to="{ name: 'create' }">CREATE</RouterLink>
+            <RouterLink class="nav-link" :to="{ name: 'moathonCreate' }">CREATE</RouterLink>
             <RouterLink class="nav-link" :to="{ name: 'mypage' }">MY PAGE</RouterLink>
             <form @submit.prevent="logOut">
               <input type="submit" class="nav-link" value="LOGOUT">

--- a/frontend/src/components/moathon/MoathonCard.vue
+++ b/frontend/src/components/moathon/MoathonCard.vue
@@ -1,0 +1,145 @@
+<template>
+  <div class="moathon-card" @click="goDetail">
+    <div class="card-header">
+      <h3 class="title">{{ moathon.title }}</h3>
+      <span class="bank-badge">{{ moathon.bank }}</span>
+    </div>
+
+    <div class="card-body">
+      <div class="info-row">
+        <span class="label">Challenger</span>
+        <span class="value">{{ moathon.nickname }}</span>
+      </div>
+      <div class="info-row">
+        <span class="label">상품</span>
+        <span class="value">{{ moathon.product_name }}</span>
+      </div>
+      
+      <div class="progress-section">
+        <div class="progress-bg">
+          <div 
+            class="progress-fill" 
+            :style="{ width: `${moathon.progress_rate}%` }"
+          ></div>
+        </div>
+        <div class="progress-text">
+          <span>달성률</span>
+          <span class="percent">{{ moathon.progress_rate }}%</span>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { useRouter } from 'vue-router'
+
+const props = defineProps({
+  moathon: {
+    type: Object,
+    required: true
+  }
+})
+
+const router = useRouter()
+
+const goDetail = () => {
+  router.push({ name: 'moathonDetail', params: { id: props.moathon.id } })
+}
+</script>
+
+<style scoped>
+.moathon-card {
+  background: white;
+  border-radius: 16px;
+  padding: 20px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
+  cursor: pointer;
+  transition: transform 0.2s, box-shadow 0.2s;
+  border: 1px solid #f0f0f0;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+}
+
+.moathon-card:hover {
+  transform: translateY(-5px);
+  box-shadow: 0 8px 20px rgba(0, 0, 0, 0.12);
+}
+
+.card-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  margin-bottom: 12px;
+}
+
+.title {
+  font-size: 1.1rem;
+  font-weight: 700;
+  color: #333;
+  margin: 0;
+  word-break: keep-all;
+  line-height: 1.4;
+}
+
+.bank-badge {
+  font-size: 0.75rem;
+  background-color: #e3f2fd;
+  color: #1976d2;
+  padding: 4px 8px;
+  border-radius: 6px;
+  white-space: nowrap;
+  margin-left: 8px;
+  flex-shrink: 0;
+}
+
+.card-body {
+  margin-top: auto;
+}
+
+.info-row {
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.9rem;
+  margin-bottom: 6px;
+  color: #666;
+}
+
+.info-row .value {
+  font-weight: 600;
+  color: #444;
+}
+
+.progress-section {
+  margin-top: 16px;
+}
+
+.progress-bg {
+  width: 100%;
+  height: 8px;
+  background-color: #eee;
+  border-radius: 4px;
+  overflow: hidden;
+}
+
+.progress-fill {
+  height: 100%;
+  background-color: #4caf50;
+  border-radius: 4px;
+  transition: width 0.5s ease;
+}
+
+.progress-text {
+  display: flex;
+  justify-content: space-between;
+  margin-top: 6px;
+  font-size: 0.8rem;
+  color: #888;
+}
+
+.progress-text .percent {
+  color: #4caf50;
+  font-weight: 700;
+}
+</style>

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -44,12 +44,12 @@ const router = createRouter({
       children: [
         {
           path: 'create',
-          name: 'create',
+          name: 'moathonCreate',
           component: MoathonCreateView,
         },
         {
           path: ':id',
-          name: 'detail',
+          name: 'moathonDetail',
           component: MoathonDetailView,
         },
       ]

--- a/frontend/src/stores/moathon.js
+++ b/frontend/src/stores/moathon.js
@@ -1,0 +1,45 @@
+import { ref, computed } from 'vue'
+import { defineStore } from 'pinia'
+import axios from 'axios'
+
+export const useMoathonStore = defineStore('moathon', () => {
+  const API_URL = import.meta.env.VITE_API_URL
+
+  const moathons = ref([])         // 화면에 보여줄 모아톤 리스트 (누적됨)
+  const count = ref(0)             // 전체 개수
+  const currentPage = ref(1)      // 현재 페이지 번호
+  const itemsPerPage = 24         // 페이지당 개수 설정
+
+  const totalPages = computed(() => {
+    return Math.ceil(count.value / itemsPerPage)
+  })
+
+  const fetchMoathons = async (page = 1) => {
+    try {
+      const response = await axios.get(`${API_URL}/moathons/`, {
+        params: {
+          page: page,
+          page_size: itemsPerPage 
+        }
+      })
+      
+      const { results, count: totalCount } = response.data
+
+      moathons.value = results
+      count.value = totalCount
+      currentPage.value = page
+
+    } catch (error) {
+      console.error('모아톤 목록 조회 실패:', error)
+    }
+  }
+
+  return { 
+    moathons, 
+    count, 
+    currentPage, 
+    itemsPerPage,
+    totalPages, 
+    fetchMoathons,
+   }
+})

--- a/frontend/src/views/moathon/MoathonListView.vue
+++ b/frontend/src/views/moathon/MoathonListView.vue
@@ -1,13 +1,221 @@
 <template>
-  <div>
-    <h1>모아톤 모아보기 페이지</h1>
+  <div class="container">
+    <header class="page-header">
+      <h1>🏆 모아톤 챌린지</h1>
+      <p>총 {{ store.count }}개의 도전이 진행 중입니다!</p>
+      
+      <RouterLink :to="{ name: 'moathonCreate' }" class="create-btn">
+        + 내 모아톤 만들기
+      </RouterLink>
+    </header>
+
+    <div v-if="store.moathons.length > 0" class="moathon-grid">
+      <MoathonCard 
+        v-for="moathon in store.moathons" 
+        :key="moathon.id" 
+        :moathon="moathon"
+      />
+    </div>
+    
+    <div v-else class="empty-state">
+      <p>등록된 모아톤이 없습니다.</p>
+    </div>
+
+    <div class="pagination" v-if="store.totalPages > 1">
+      <button 
+        :disabled="store.currentPage === 1" 
+        @click="changePage(1)"
+        class="page-btn nav-btn"
+      >
+        &lt;&lt;
+      </button>
+
+      <button 
+        :disabled="store.currentPage === 1" 
+        @click="changePage(store.currentPage - 1)"
+        class="page-btn nav-btn"
+      >
+        &lt;
+      </button>
+
+      <button 
+        v-for="page in visiblePages" 
+        :key="page"
+        @click="changePage(page)"
+        class="page-btn number-btn"
+        :class="{ active: page === store.currentPage }"
+      >
+        {{ page }}
+      </button>
+
+      <button 
+        :disabled="store.currentPage === store.totalPages" 
+        @click="changePage(store.currentPage + 1)"
+        class="page-btn nav-btn"
+      >
+        &gt;
+      </button>
+
+      <button 
+        :disabled="store.currentPage === store.totalPages" 
+        @click="changePage(store.totalPages)"
+        class="page-btn nav-btn"
+      >
+        &gt;&gt;
+      </button>
+    </div>
   </div>
 </template>
 
 <script setup>
+import { onMounted, computed } from 'vue'
+import { RouterLink } from 'vue-router'
+import { useMoathonStore } from '@/stores/moathon'
+import MoathonCard from '@/components/moathon/MoathonCard.vue'
 
+const store = useMoathonStore()
+
+// 페이지 변경 핸들러
+const changePage = (page) => {
+  if (page >= 1 && page <= store.totalPages) {
+    store.fetchMoathons(page)
+    window.scrollTo({ top: 0, behavior: 'smooth' })
+  }
+}
+
+// 화면에 보여줄 페이지 번호 계산 (최대 5개씩 노출)
+const visiblePages = computed(() => {
+  const current = store.currentPage
+  const total = store.totalPages
+  const maxVisible = 5
+  
+  let start = current - Math.floor(maxVisible / 2)
+  start = Math.max(start, 1)
+  
+  let end = start + maxVisible - 1
+  end = Math.min(end, total)
+
+  // 끝 부분 보정 (예: 총 10페이지인데 현재 9페이지면 6,7,8,9,10 보여줌)
+  if (end - start + 1 < maxVisible) {
+    start = Math.max(end - maxVisible + 1, 1)
+  }
+
+  const pages = []
+  for (let i = start; i <= end; i++) {
+    pages.push(i)
+  }
+  return pages
+})
+
+onMounted(() => {
+  store.fetchMoathons(1)
+})
 </script>
 
 <style scoped>
+.container {
+  /* 4개를 배치하기 위해 최대 너비를 1200px -> 1320px 정도로 확장 */
+  max-width: 1320px; 
+  margin: 0 auto;
+  padding: 40px 16px; 
+}
 
+.page-header {
+  text-align: center;
+  margin-bottom: 40px;
+}
+
+.create-btn {
+  display: inline-block;
+  margin-top: 20px;
+  padding: 10px 24px;
+  background-color: #2c3e50;
+  color: white;
+  text-decoration: none;
+  border-radius: 30px;
+  font-weight: bold;
+}
+
+/* 그리드 레이아웃 수정 */
+.moathon-grid {
+  display: grid;
+  gap: 20px; /* 카드 간격 24px -> 20px로 조금 좁힘 */
+  
+  /* 기본(모바일): 1열 */
+  grid-template-columns: repeat(1, 1fr);
+}
+
+/* 태블릿 (작은 화면): 2열 */
+@media (min-width: 640px) {
+  .moathon-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+/* 태블릿 (큰 화면) / 작은 노트북: 3열 */
+@media (min-width: 960px) {
+  .moathon-grid {
+    grid-template-columns: repeat(3, 1fr);
+  }
+}
+
+/* 데스크탑: 4열 (최대 4개) */
+@media (min-width: 1280px) {
+  .moathon-grid {
+    grid-template-columns: repeat(4, 1fr);
+  }
+}
+
+.empty-state {
+  text-align: center;
+  padding: 80px 0;
+  color: #888;
+}
+
+/* 페이지네이션 스타일 (기존 유지) */
+.pagination {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 8px;
+  margin-top: 50px;
+}
+
+.page-btn {
+  background: white;
+  border: 1px solid #ddd;
+  min-width: 36px; /* 버튼 크기 살짝 조정 */
+  height: 36px;
+  border-radius: 8px;
+  cursor: pointer;
+  font-size: 0.9rem;
+  color: #555;
+  transition: all 0.2s;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.page-btn:hover:not(:disabled) {
+  background-color: #f0f0f0;
+  border-color: #bbb;
+}
+
+.page-btn:disabled {
+  cursor: not-allowed;
+  opacity: 0.5;
+  background-color: #f9f9f9;
+}
+
+.page-btn.active {
+  background-color: #2c3e50;
+  color: white;
+  border-color: #2c3e50;
+  font-weight: bold;
+}
+
+.nav-btn {
+  font-weight: bold;
+  color: #888;
+}
 </style>


### PR DESCRIPTION
## 💡 개요 (Overview)
> 이 코드가 '왜' 작성되었는지 한 줄로 파악하게 합니다.

## 📃 작업 내용 (Details)
- **모아톤 리스트 페이지 (`MoathonListView`) 개발**: 전체 유저의 모아톤을 카드 형태로 조회하는 페이지를 구현했습니다.
- **반응형 그리드 적용**: 화면 크기에 따라 1열(모바일) ~ 4열(데스크탑)로 레이아웃이 변경되도록 CSS Grid를 활용했습니다.
- **페이지네이션 구현**:
  - 기존 무한 스크롤 방식에서 페이지 번호(`<< < 1 2 3 > >>`) 이동 방식으로 변경했습니다.
  - 한 페이지당 24개의 아이템을 보여줍니다.

## 🔗 관련 이슈 (Links)
- Closes #66 


## 📸 스크린샷 (Screenshots)
<img width="1226" height="1345" alt="image" src="https://github.com/user-attachments/assets/efc48524-4f9a-4697-8403-7cf7870753c1" />
