### PR TITLE
fix(frontend): 온보딩 프로필 저장 후 메인 페이지로 이동하도록 수정

### DIFF
--- a/frontend/src/stores/accounts.js
+++ b/frontend/src/stores/accounts.js
@@ -22,7 +22,7 @@ export const useAccountStore = defineStore('account', () => {
         console.log('회원가입이 완료되었습니다.')
         const password = password1
         logIn({ username, email, password })
-        router.replace({ name: 'onboarding' })
+        router.push({ name: 'onboarding' })
       })
       .catch(err => console.log(err))
   }
@@ -40,7 +40,6 @@ export const useAccountStore = defineStore('account', () => {
       .then(res => {
         console.log('로그인이 완료되었습니다.')
         token.value = res.data.key
-        router.push({ name: 'home' })
       })
       .catch(err => console.log(err))
   }
@@ -64,9 +63,9 @@ export const useAccountStore = defineStore('account', () => {
   })
 
   const updateProfile = function (payload) {
-    axios({
+    return axios({
       method: 'patch',
-      url: `${API_URL}/accounts/user/`,
+      url: `${API_URL}/accounts/onboarding/`,
       data: payload,
       headers: {
         Authorization: `Token ${token.value}`,
@@ -75,6 +74,7 @@ export const useAccountStore = defineStore('account', () => {
     })
       .then(res => {
         console.log('프로필 정보가 저장되었습니다.', res.data)
+        return res.data
       })
       .catch(err => console.log(err))
   }

--- a/frontend/src/views/auth/LoginView.vue
+++ b/frontend/src/views/auth/LoginView.vue
@@ -20,12 +20,14 @@
 <script setup>
   import { ref } from 'vue';
   import { useAccountStore } from '@/stores/accounts';
+  import { useRouter } from 'vue-router';
 
   const username = ref(null)
   const email = ref(null)
   const password = ref(null)
 
   const accountStore = useAccountStore()
+  const router = useRouter()
 
   const logIn = function () {
     const payload = {
@@ -34,6 +36,7 @@
       password: password.value,
     }
     accountStore.logIn(payload)
+    router.push({ name: 'home' })
   }
 </script>
 


### PR DESCRIPTION
## 💡 개요 (Overview)
> 온보딩 페이지 연결 문제를 해결했습니다.

## 📃 작업 내용 (Details)
- useAccountStore의 updateProfile 액션이 Promise를 반환하지 않는 문제 해결
- axios 요청 객체를 return하여 컴포넌트에서 await로 대기할 수 있도록 수정
- 프로필 저장이 성공한 후에만 success 이벤트를 emit 하도록 개선


## 🔗 관련 이슈 (Links)
- Closes #70 


## 📸 스크린샷 (Screenshots)
<img width="1223" height="583" alt="image" src="https://github.com/user-attachments/assets/2efe514f-181d-4d26-8f1c-5a5e209409f3" />
