### PR TITLE
[FEAT] 금/은 시세 조회 페이지 및 차트 시각화 구현

### DIFF
--- a/backend/visualizations/urls.py
+++ b/backend/visualizations/urls.py
@@ -2,5 +2,5 @@ from django.urls import path
 from . import views
 
 urlpatterns = [
-    path("commodities/prices", views.commodity_price_series),
+    path("commodities/prices/", views.commodity_price_series),
 ]

--- a/frontend/src/components/commodity/CommodityChart.vue
+++ b/frontend/src/components/commodity/CommodityChart.vue
@@ -1,0 +1,127 @@
+<template>
+  <div class="chart-wrapper">
+    <div v-if="!isLoaded" class="loading-state">
+      <div class="spinner"></div>
+      <p>차트 데이터를 불러오는 중입니다...</p>
+    </div>
+    <div ref="chartRef" class="chart-div"></div>
+  </div>
+</template>
+
+<script setup>
+import { ref, watch, onMounted } from 'vue'
+import { useGoogleCharts } from '@/composables/useGoogleCharts'
+
+const props = defineProps({
+  chartData: {
+    type: Array,
+    required: true,
+    default: () => []
+  },
+  type: {
+    type: String, 
+    default: 'gold'
+  }
+})
+
+const chartRef = ref(null)
+const { isLoaded, loadCharts } = useGoogleCharts()
+let chartInstance = null
+
+const drawChart = (google) => {
+  if (!chartRef.value || props.chartData.length === 0) return
+
+  // 1. 데이터 포맷 변환
+  const dataHeader = ['Date', 'Low', 'Open', 'Close', 'High']
+
+  const dataRows = props.chartData.map(item => {
+    return [
+      item.date,            
+      item.low,             
+      item.open,            
+      item.close_last,      
+      item.high             
+    ]
+  })
+
+  const data = google.visualization.arrayToDataTable([
+    dataHeader,
+    ...dataRows
+  ], false) 
+
+  // 2. [수정] 차트 옵션 설정
+  const options = {
+    legend: 'none',
+    candlestick: {
+      fallingColor: { strokeWidth: 0, fill: '#4c6ef5' }, 
+      risingColor: { strokeWidth: 0, fill: '#fa5252' }   
+    },
+    colors: ['#222'],
+    vAxis: { 
+      format: 'short',
+      title: '가격 (USD/KRW)'
+    },
+    // [추가] X축 스타일링 옵션
+    hAxis: { 
+      slantedText: true,       // 텍스트를 기울임
+      slantedTextAngle: 45,    // 45도 회전
+      showTextEvery: 1,        // 모든 라벨을 강제로 표시 (생략 방지)
+      textStyle: {
+        fontSize: 11           // 글자가 많을 경우를 대비해 크기 조정
+      }
+    },
+    // [수정] 차트 영역 조정 (라벨 공간 확보를 위해 height를 80% -> 70%로 축소)
+    chartArea: { width: '85%', height: '70%' }, 
+    animation: {
+      startup: true,
+      duration: 1000,
+      easing: 'out'
+    },
+    backgroundColor: 'transparent'
+  }
+
+  chartInstance = new google.visualization.CandlestickChart(chartRef.value)
+  chartInstance.draw(data, options)
+}
+
+onMounted(async () => {
+  const google = await loadCharts()
+  drawChart(google)
+})
+
+watch(() => props.chartData, () => {
+  if (isLoaded.value && window.google) {
+    drawChart(window.google)
+  }
+}, { deep: true })
+</script>
+
+<style scoped>
+/* 기존 스타일 유지 */
+.chart-wrapper {
+  width: 100%;
+  height: 500px;
+  position: relative;
+  background: white;
+  border-radius: 12px;
+  box-shadow: 0 4px 20px rgba(0,0,0,0.05);
+  padding: 20px;
+}
+.chart-div { width: 100%; height: 100%; }
+.loading-state {
+  position: absolute;
+  top: 50%; left: 50%;
+  transform: translate(-50%, -50%);
+  text-align: center;
+  color: #888;
+}
+.spinner {
+  width: 40px; height: 40px;
+  border: 4px solid #f3f3f3;
+  border-top: 4px solid #2c3e50;
+  border-radius: 50%;
+  animation: spin 1s linear infinite;
+  margin: 0 auto 10px;
+}
+@keyframes spin { 0% { transform: rotate(0deg); } 100% { transform: rotate(360deg); } }
+</style>

--- a/frontend/src/components/common/Navbar.vue
+++ b/frontend/src/components/common/Navbar.vue
@@ -14,6 +14,7 @@
           <RouterLink class="nav-link" :to="{ name: 'home' }">HOME</RouterLink>
           <RouterLink class="nav-link" :to="{ name: 'explore' }">EXPLORE</RouterLink>
           <RouterLink class="nav-link" :to="{ name: 'videoSearch' }">종목 검색</RouterLink>
+          <RouterLink class="nav-link" :to="{ name: 'commodity' }">금/은 시세</RouterLink>
           <RouterLink class="nav-link" :to="{ name: 'bank' }">은행 찾기</RouterLink>
           
           <template v-if="!accountStore.isAuthenticated">

--- a/frontend/src/composables/useGoogleCharts.js
+++ b/frontend/src/composables/useGoogleCharts.js
@@ -1,0 +1,61 @@
+import { ref } from 'vue'
+
+// 전역 상태로 관리하여 앱 어디서든 한 번만 로드되도록 함
+const isLoaded = ref(false)
+const isLoading = ref(false)
+
+export const useGoogleCharts = () => {
+  const loadCharts = () => {
+    return new Promise((resolve, reject) => {
+      // 1. 이미 로드가 완료된 경우 즉시 반환
+      if (window.google && window.google.charts && isLoaded.value) {
+        resolve(window.google)
+        return
+      }
+
+      // 2. 다른 컴포넌트에서 이미 로딩을 시작한 경우 (폴링으로 대기)
+      if (isLoading.value) {
+        const checkInterval = setInterval(() => {
+          if (isLoaded.value && window.google) {
+            clearInterval(checkInterval)
+            resolve(window.google)
+          }
+        }, 100)
+        return
+      }
+
+      // 3. 최초 로딩 시작
+      isLoading.value = true
+      
+      const script = document.createElement('script')
+      script.src = 'https://www.gstatic.com/charts/loader.js'
+      script.async = true
+      script.defer = true
+      
+      script.onload = () => {
+        if (!window.google) {
+          reject(new Error('Google Charts loader failed to load'))
+          return
+        }
+
+        // 'corechart' 패키지에는 LineChart, BarChart, CandlestickChart 등이 포함됨
+        window.google.charts.load('current', { packages: ['corechart'] })
+        
+        window.google.charts.setOnLoadCallback(() => {
+          isLoaded.value = true
+          isLoading.value = false
+          resolve(window.google)
+        })
+      }
+      
+      script.onerror = (err) => {
+        isLoading.value = false
+        reject(err)
+      }
+      
+      document.head.appendChild(script)
+    })
+  }
+
+  return { isLoaded, loadCharts }
+}

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -3,6 +3,7 @@ import LoginView from '@/views/auth/LoginView.vue'
 import OnboardingView from '@/views/auth/OnboardingView.vue'
 import SignupView from '@/views/auth/SignupView.vue'
 import BankSearchView from '@/views/finance/BankSearchView.vue'
+import CommoditySearchView from '@/views/finance/CommoditySearchView.vue'
 import VideoSearchView from '@/views/finance/VideoSearchView.vue'
 import HomeView from '@/views/HomeView.vue'
 import MoathonCreateView from '@/views/moathon/MoathonCreateView.vue'
@@ -78,6 +79,11 @@ const router = createRouter({
       path: '/bank',
       name: 'bank',
       component: BankSearchView,
+    },
+    {
+      path: '/commodity',
+      name: 'commodity',
+      component: CommoditySearchView,
     },
   ],
 })

--- a/frontend/src/views/finance/CommoditySearchView.vue
+++ b/frontend/src/views/finance/CommoditySearchView.vue
@@ -1,0 +1,222 @@
+<template>
+  <div class="market-container">
+    <div class="header-section">
+      <h1>📈 금/은 시세 조회</h1>
+      <p>원하는 기간의 시세 변동을 확인해보세요.</p>
+    </div>
+
+    <div class="filter-controls">
+      <div class="date-group">
+        <label>기간:</label>
+        <input type="date" v-model="startDate" class="date-input" />
+        <span>~</span>
+        <input type="date" v-model="endDate" class="date-input" />
+      </div>
+      <button @click="fetchMarketPrices(selectedAsset)" class="search-btn">
+        조회
+      </button>
+    </div>
+
+    <div class="tabs">
+      <button 
+        v-for="type in ['gold', 'silver']" 
+        :key="type"
+        @click="changeAssetType(type)"
+        :class="['tab-btn', { active: selectedAsset === type }]"
+      >
+        {{ type === 'gold' ? '금 (Gold)' : '은 (Silver)' }}
+      </button>
+    </div>
+
+    <div class="chart-section">
+      <CommodityChart 
+        v-if="marketData.length > 0" 
+        :chartData="marketData" 
+        :type="selectedAsset" 
+      />
+      <div v-else-if="!isLoading" class="no-data">
+        선택한 기간에 데이터가 없습니다.
+      </div>
+      <div v-else class="loading-indicator">로딩중...</div>
+    </div>
+
+    <div class="table-section" v-if="marketData.length > 0">
+      <h3>상세 시세표</h3>
+      <table class="data-table">
+        <thead>
+          <tr>
+            <th>날짜</th>
+            <th>시가</th>
+            <th>고가</th>
+            <th>저가</th>
+            <th>종가</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr v-for="item in [...marketData].reverse()" :key="item.date">
+            <td>{{ item.date }}</td>
+            <td>{{ item.open.toLocaleString() }}</td>
+            <td class="high">{{ item.high.toLocaleString() }}</td>
+            <td class="low">{{ item.low.toLocaleString() }}</td>
+            <td :class="getPriceColor(item)">
+              {{ item.close_last.toLocaleString() }}
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref, onMounted } from 'vue'
+import axios from 'axios'
+import { useAccountStore } from '@/stores/accounts'
+import CommodityChart from '@/components/commodity/CommodityChart.vue'
+
+const accountStore = useAccountStore()
+const marketData = ref([])
+const selectedAsset = ref('gold')
+const isLoading = ref(false)
+
+const today = new Date().toISOString().split('T')[0]
+const oneMonthAgo = new Date()
+oneMonthAgo.setMonth(oneMonthAgo.getMonth() - 1)
+const lastMonth = oneMonthAgo.toISOString().split('T')[0]
+
+const startDate = ref(lastMonth)
+const endDate = ref(today)
+
+// 상승/하락 색상 결정
+const getPriceColor = (item) => {
+  if (item.close_last > item.open) return 'rising'
+  if (item.close_last < item.open) return 'falling'
+  return ''
+}
+
+// 데이터 조회 함수
+const fetchMarketPrices = async (assetType) => {
+  if (startDate.value > endDate.value) {
+    alert('종료일이 시작일보다 빠를 수 없습니다.')
+    return
+  }
+
+  isLoading.value = true
+  marketData.value = [] // 탭 전환 시 데이터 초기화 (깜빡임 방지)
+  
+  try {
+    // 백엔드 API 호출
+    const response = await axios.get(`${accountStore.API_URL}/visualizations/commodities/prices`, {
+      params: { 
+        asset: assetType,
+        start: startDate.value,
+        end: endDate.value
+      }
+    })
+    
+    // 응답 예시: { asset: "gold", data: [ ... ] }
+    // 실제 차트에 필요한 데이터 배열만 추출
+    if (response.data && response.data.data) {
+      marketData.value = response.data.data
+    }
+  } catch (error) {
+    console.error('시세 조회 실패:', error)
+  } finally {
+    isLoading.value = false
+  }
+}
+
+// 탭 변경 핸들러
+const changeAssetType = (type) => {
+  selectedAsset.value = type
+  fetchMarketPrices(type)
+}
+
+onMounted(() => {
+  fetchMarketPrices(selectedAsset.value)
+})
+</script>
+
+<style scoped>
+.market-container {
+  max-width: 900px;
+  margin: 0 auto;
+  padding: 40px 20px;
+}
+.header-section { text-align: center; margin-bottom: 30px; }
+.filter-controls {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 24px;
+  background: #f8f9fa;
+  padding: 15px;
+  border-radius: 12px;
+}
+
+.date-group {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-weight: bold;
+  color: #555;
+}
+
+.date-input {
+  padding: 8px 12px;
+  border: 1px solid #ddd;
+  border-radius: 8px;
+  font-family: inherit;
+}
+.date-input {
+  padding: 8px 12px;
+  border: 1px solid #ddd;
+  border-radius: 8px;
+  font-family: inherit;
+}
+
+.search-btn {
+  padding: 8px 20px;
+  background-color: #2c3e50;
+  color: white;
+  border: none;
+  border-radius: 8px;
+  cursor: pointer;
+  font-weight: bold;
+  transition: background 0.2s;
+}
+
+.search-btn:hover {
+  background-color: #3e5871;
+}
+
+.tabs {
+  display: flex; justify-content: center; gap: 12px; margin-bottom: 20px;
+}
+.tab-btn {
+  padding: 10px 24px; border-radius: 50px; border: 1px solid #ddd;
+  background: white; cursor: pointer; font-weight: 600; text-transform: capitalize;
+  transition: all 0.2s;
+}
+.tab-btn.active {
+  background: #2c3e50; color: white; border-color: #2c3e50;
+}
+.chart-section { margin-bottom: 50px; min-height: 500px; }
+.no-data { text-align: center; padding: 50px; color: #888; }
+.table-section {
+  background: white; padding: 24px; border-radius: 12px;
+  box-shadow: 0 4px 12px rgba(0,0,0,0.05);
+}
+.data-table {
+  width: 100%; border-collapse: collapse; text-align: center;
+}
+.data-table th {
+  background: #f8f9fa; padding: 12px; font-weight: bold; color: #495057;
+}
+.data-table td { padding: 12px; border-bottom: 1px solid #eee; }
+.high { color: #fa5252; }
+.low { color: #4c6ef5; }
+.rising { color: #fa5252; font-weight: bold; }
+.falling { color: #4c6ef5; font-weight: bold; }
+</style>


### PR DESCRIPTION
## 💡 개요 (Overview)
금/은 시세 조회 페이지에서 원형 차트로 시세 흐름을 시각화합니다.

## 📃 작업 내용 (Details)
- **금/은 시세 조회 기능**을 구현했습니다. 
- Google Charts의 **Candlestick Chart**를 도입하여 시가/종가/고가/저가 흐름을 시각적으로 제공합니다.
- `useGoogleCharts` Composable을 만들어 차트 라이브러리 로딩을 최적화했습니다.
- 날짜 필터링 기능을 추가하여 원하는 기간의 데이터를 조회할 수 있습니다.


## 🔗 관련 이슈 (Links)
- Closes #55 

## 📸 스크린샷 (Screenshots)
<img width="1274" height="1346" alt="image" src="https://github.com/user-attachments/assets/e290549e-f883-4591-b489-5023e7e2ba2b" />

## 🎸 기타 사항 & 트러블 슈팅 (Notes)
문제상황: 404 Not Found 에러 발생
원인: 백엔드 API URL에 `/`이 누락되었음
해결: `path("commodities/prices/", views.commodity_price_series),`
