### PR TITLE
feat(moathon): 모아톤 생성 및 추천 프로세스 구현 완료

### DIFF
--- a/backend/challenges/models.py
+++ b/backend/challenges/models.py
@@ -40,10 +40,9 @@ class Moathon(models.Model):
             models.UniqueConstraint(fields=["user", "title"], name="uniq_moathon_title_per_user"),
         ]
 
-    DEFAULT_TITLE_BASE = f"{user}\'s moathon"
-
     def _next_default_title(self) -> str:
-        base = self.DEFAULT_TITLE_BASE
+        nickname = getattr(self.user, 'nickname', self.user.username)
+        base = f"{nickname}'s moathon"
         titles = (Moathon.objects
                   .filter(user=self.user, title__startswith=base)
                   .values_list("title", flat=True))

--- a/frontend/src/components/common/Navbar.vue
+++ b/frontend/src/components/common/Navbar.vue
@@ -22,7 +22,7 @@
           </template>
           
           <template v-else>
-            <RouterLink class="nav-link" :to="{ name: 'moathonCreate' }">CREATE</RouterLink>
+            <RouterLink class="nav-link" :to="{ name: 'moathonRecommend' }">모아톤 추천받기</RouterLink>
             <RouterLink class="nav-link" :to="{ name: 'mypage' }">MY PAGE</RouterLink>
             <form @submit.prevent="logOut">
               <input type="submit" class="nav-link" value="LOGOUT">

--- a/frontend/src/components/moathon/MoathonCreateForm.vue
+++ b/frontend/src/components/moathon/MoathonCreateForm.vue
@@ -1,0 +1,128 @@
+<template>
+  <div class="form-container">
+    <form @submit.prevent="submitForm">
+
+      <div class="form-group">
+        <label for="title">모아톤 이름</label>
+        <input type="text" id="title" v-model="formData.title" placeholder="예: 유럽 여행 가자!" required />
+      </div>
+
+      <div class="form-group">
+        <label for="target_amount">목표 금액 (원)</label>
+        <input type="number" id="target_amount" v-model.number="formData.target_amount" placeholder="목표 금액을 입력하세요"
+          required min="0" />
+      </div>
+
+      <div class="form-group">
+        <label for="start_amount">시작 금액 (원)</label>
+        <input type="number" id="start_amount" v-model.number="formData.start_amount" placeholder="처음 입금할 금액을 입력하세요"
+          required min="0" />
+      </div>
+
+      <div class="form-group">
+        <label for="purpose">저축 목적</label>
+        <select id="purpose" v-model="formData.purpose" required>
+          <option value="" disabled>목적을 선택해주세요</option>
+          <option value="GOAL">목돈 만들기</option>
+          <option value="SHORT">단기 여유자금</option>
+          <option value="SAFE">안정적 자산 보관</option>
+          <option value="YIELD">이자 극대화</option>
+          <option value="HABIT">저축 습관 형성</option>
+        </select>
+      </div>
+
+      <button type="submit" class="submit-btn" :disabled="isSubmitting">
+        {{ isSubmitting ? '생성 중...' : '모아톤 시작하기' }}
+      </button>
+    </form>
+  </div>
+</template>
+
+<script setup>
+import { reactive } from 'vue'
+
+const props = defineProps({
+  isSubmitting: Boolean
+})
+
+const emit = defineEmits(['submit'])
+
+const formData = reactive({
+  title: '',
+  purpose: 'GOAL',
+  target_amount: null,
+  start_amount: null
+})
+
+const submitForm = () => {
+  emit('submit', { ...formData })
+}
+</script>
+
+<style scoped>
+.form-container {
+  width: 100%;
+}
+
+.form-group {
+  margin-bottom: 20px;
+}
+
+.form-group label {
+  display: block;
+  font-weight: 600;
+  margin-bottom: 8px;
+  color: #333;
+}
+
+.info-text {
+  font-size: 0.8rem;
+  color: #888;
+  font-weight: normal;
+}
+
+input,
+select {
+  width: 100%;
+  padding: 12px;
+  border: 1px solid #ddd;
+  border-radius: 8px;
+  font-size: 1rem;
+  box-sizing: border-box;
+  /* 패딩 포함 너비 계산 */
+}
+
+input:focus,
+select:focus {
+  border-color: #2c3e50;
+  outline: none;
+}
+
+input[readonly] {
+  background-color: #f5f5f5;
+  color: #666;
+}
+
+.submit-btn {
+  width: 100%;
+  padding: 15px;
+  background-color: #2c3e50;
+  color: white;
+  border: none;
+  border-radius: 12px;
+  font-size: 1.1rem;
+  font-weight: bold;
+  cursor: pointer;
+  transition: background-color 0.2s;
+  margin-top: 10px;
+}
+
+.submit-btn:disabled {
+  background-color: #95a5a6;
+  cursor: not-allowed;
+}
+
+.submit-btn:hover:not(:disabled) {
+  background-color: #34495e;
+}
+</style>

--- a/frontend/src/components/moathon/MoathonRecommendCard.vue
+++ b/frontend/src/components/moathon/MoathonRecommendCard.vue
@@ -1,0 +1,253 @@
+<template>
+  <div class="detail-card">
+    <div class="card-header">
+      <span class="bank-badge">{{ detail.bank_name }}</span>
+      <h3 class="product-title">{{ detail.product_name }}</h3>
+      <div class="rate-highlight">
+        <span class="label">최고 금리</span>
+        <span class="value">{{ detail.intr_rate2 }}%</span>
+      </div>
+    </div>
+
+    <hr class="divider" />
+
+    <div class="options-grid">
+      <div class="option-item">
+        <span class="opt-label">기본 금리</span>
+        <span class="opt-value">{{ detail.intr_rate }}%</span>
+      </div>
+      <div class="option-item">
+        <span class="opt-label">저축 기간</span>
+        <span class="opt-value">{{ detail.save_trm }}개월</span>
+      </div>
+      <div class="option-item">
+        <span class="opt-label">적립 방식</span>
+        <span class="opt-value">{{ detail.rsrv_type_nm }}</span>
+      </div>
+      <div class="option-item">
+        <span class="opt-label">이자 계산</span>
+        <span class="opt-value">{{ detail.intr_rate_type_nm }}</span>
+      </div>
+    </div>
+
+    <div class="detail-text-section">
+      <div class="text-group" v-if="detail.spcl_cnd">
+        <h4>우대 조건</h4>
+        <p>{{ detail.spcl_cnd }}</p>
+      </div>
+
+      <div class="text-group" v-if="detail.etc_note">
+        <h4>기타 설명</h4>
+        <p>{{ detail.etc_note }}</p>
+      </div>
+
+      <div class="text-group" v-if="detail.mtrt_int">
+        <h4>만기 후 이자율</h4>
+        <p>{{ detail.mtrt_int }}</p>
+      </div>
+
+      <div class="warning-box" v-if="warnings && warnings.length > 0">
+        <h4>가입 전 유의사항</h4>
+        <ul>
+          <li v-for="(warn, idx) in warnings" :key="idx">
+            {{ warn }}
+          </li>
+        </ul>
+      </div>
+    </div>
+
+    <div class="action-buttons">
+      <button @click="$emit('create')" class="start-btn">
+        이 상품으로 시작하기
+      </button>
+      <button @click="$emit('retry')" class="retry-btn">
+        다시 추천 받기
+      </button>
+    </div>
+  </div>
+</template>
+
+<script setup>
+defineProps({
+  detail: {
+    type: Object,
+    required: true
+  },
+  warnings: {
+    type: Array,
+    default: () => []
+  }
+})
+
+defineEmits(['create', 'retry'])
+</script>
+
+<style scoped>
+.detail-card {
+  background: white;
+  padding: 30px;
+  border-radius: 16px;
+  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.08);
+  border: 1px solid #eee;
+}
+
+.card-header {
+  text-align: center;
+  margin-bottom: 20px;
+}
+
+.bank-badge {
+  background: #e3f2fd;
+  color: #1976d2;
+  font-size: 0.85rem;
+  padding: 4px 10px;
+  border-radius: 6px;
+  font-weight: 600;
+}
+
+.product-title {
+  font-size: 1.6rem;
+  margin: 12px 0;
+  color: #333;
+}
+
+.rate-highlight {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  background: #fff5f5;
+  color: #e74c3c;
+  padding: 8px 16px;
+  border-radius: 20px;
+  font-weight: bold;
+}
+
+.rate-highlight .value {
+  font-size: 1.4rem;
+}
+
+.divider {
+  border: 0;
+  height: 1px;
+  background: #eee;
+  margin: 24px 0;
+}
+
+.options-grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 16px;
+  margin-bottom: 24px;
+}
+
+.option-item {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  background: #f8f9fa;
+  padding: 12px;
+  border-radius: 12px;
+}
+
+.opt-label {
+  font-size: 0.85rem;
+  color: #666;
+  margin-bottom: 4px;
+}
+
+.opt-value {
+  font-size: 1.1rem;
+  font-weight: 600;
+  color: #2c3e50;
+}
+
+.detail-text-section {
+  margin-bottom: 30px;
+}
+
+.text-group {
+  margin-bottom: 20px;
+}
+
+.text-group h4 {
+  font-size: 1rem;
+  color: #2c3e50;
+  margin-bottom: 8px;
+  font-weight: 700;
+}
+
+.text-group p {
+  font-size: 0.95rem;
+  color: #555;
+  line-height: 1.6;
+  white-space: pre-line;
+  background: #fff;
+  padding: 0;
+}
+
+.warning-box {
+  background-color: #fff8e1;
+  border: 1px solid #ffe0b2;
+  color: #bf360c;
+  padding: 20px;
+  border-radius: 12px;
+  margin-top: 25px;
+}
+
+.warning-box h4 {
+  font-size: 1rem;
+  font-weight: bold;
+  margin-bottom: 10px;
+}
+
+.warning-box ul {
+  list-style-type: disc;
+  padding-left: 20px;
+  margin: 0;
+}
+
+.warning-box li {
+  margin-bottom: 6px;
+  font-size: 0.95rem;
+  line-height: 1.5;
+}
+
+.action-buttons {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.start-btn {
+  width: 100%;
+  padding: 16px;
+  background: #2c3e50;
+  color: white;
+  border: none;
+  border-radius: 12px;
+  font-size: 1.1rem;
+  font-weight: bold;
+  cursor: pointer;
+  transition: background 0.2s;
+}
+
+.start-btn:hover {
+  background: #34495e;
+}
+
+.retry-btn {
+  width: 100%;
+  padding: 14px;
+  background: white;
+  color: #666;
+  border: 1px solid #ddd;
+  border-radius: 12px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.2s;
+}
+
+.retry-btn:hover {
+  background: #f1f3f5;
+}
+</style>

--- a/frontend/src/components/moathon/MoathonRecommendForm.vue
+++ b/frontend/src/components/moathon/MoathonRecommendForm.vue
@@ -1,0 +1,98 @@
+<template>
+  <div class="form-container">
+    <form @submit.prevent="submitForm">
+      <div class="form-group">
+        <label for="purpose">저축 목적</label>
+        <select id="purpose" v-model="formData.purpose" required>
+          <option value="" disabled>목적을 선택해주세요</option>
+          <option value="GOAL">목돈 만들기</option>
+          <option value="SHORT">단기 여유자금</option>
+          <option value="SAFE">안정적 자산 보관</option>
+          <option value="YIELD">이자 극대화</option>
+          <option value="HABIT">저축 습관 형성</option>
+        </select>
+      </div>
+
+      <div class="form-group">
+        <label for="target_amount">목표 금액 (원)</label>
+        <input type="number" id="target_amount" v-model.number="formData.target_amount" placeholder="예: 10000000"
+          required />
+      </div>
+
+      <div class="form-group">
+        <label for="start_amount">시작 금액 (원)</label>
+        <input type="number" id="start_amount" v-model.number="formData.start_amount" placeholder="예: 2000000"
+          required />
+      </div>
+
+      <div class="form-group">
+        <label for="term_months">저축 기간 (개월)</label>
+        <input type="number" id="term_months" v-model.number="formData.term_months" placeholder="예: 12" required />
+      </div>
+
+      <button type="submit" class="submit-btn" :disabled="isLoading">
+        {{ isLoading ? 'AI 분석 중...' : '맞춤 상품 추천받기' }}
+      </button>
+    </form>
+  </div>
+</template>
+
+<script setup>
+import { reactive } from 'vue'
+
+const props = defineProps({
+  isLoading: Boolean
+})
+
+const emit = defineEmits(['submit'])
+
+const formData = reactive({
+  purpose: 'GOAL',
+  target_amount: null,
+  start_amount: null,
+  term_months: 12
+})
+
+const submitForm = () => {
+  emit('submit', { ...formData })
+}
+</script>
+
+<style scoped>
+.form-container {
+  width: 100%;
+}
+
+.form-group {
+  margin-bottom: 20px;
+}
+
+label {
+  display: block;
+  margin-bottom: 8px;
+  font-weight: bold;
+}
+
+input,
+select {
+  width: 100%;
+  padding: 12px;
+  border: 1px solid #ddd;
+  border-radius: 8px;
+}
+
+.submit-btn {
+  width: 100%;
+  padding: 15px;
+  background: #2c3e50;
+  color: white;
+  border: none;
+  border-radius: 8px;
+  font-weight: bold;
+  cursor: pointer;
+}
+
+.submit-btn:disabled {
+  background: #95a5a6;
+}
+</style>

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -8,6 +8,7 @@ import HomeView from '@/views/HomeView.vue'
 import MoathonCreateView from '@/views/moathon/MoathonCreateView.vue'
 import MoathonDetailView from '@/views/moathon/MoathonDetailView.vue'
 import MoathonListView from '@/views/moathon/MoathonListView.vue'
+import MoathonRecommendView from '@/views/moathon/MoathonRecommendView.vue'
 import MyPageView from '@/views/user/MyPageView.vue'
 import { createRouter, createWebHistory } from 'vue-router'
 
@@ -43,9 +44,22 @@ const router = createRouter({
       path: '/moathon',
       children: [
         {
+          path: 'recommend',
+          name: 'moathonRecommend',
+          component: MoathonRecommendView,
+        },
+        {
           path: 'create',
           name: 'moathonCreate',
           component: MoathonCreateView,
+          // 다이렉트 모드는 productId가 필수이므로, 없으면 추천 페이지로 리다이렉트하는 가드 추가
+          beforeEnter: (to, from, next) => {
+            if (!to.query.productId) {
+              next({ name: 'moathonRecommend' })
+            } else {
+              next()
+            }
+          }
         },
         {
           path: ':id',

--- a/frontend/src/stores/accounts.js
+++ b/frontend/src/stores/accounts.js
@@ -6,6 +6,8 @@ import { useRouter } from 'vue-router'
 export const useAccountStore = defineStore('account', () => {
   const router = useRouter()
   const API_URL = import.meta.env.VITE_API_URL
+
+  const user = ref(null)
   const token = ref(null)
 
   const signUp = function (payload) {
@@ -37,11 +39,33 @@ export const useAccountStore = defineStore('account', () => {
         username, email, password
       }
     })
-      .then(res => {
+      .then(async res => {
         console.log('로그인이 완료되었습니다.')
         token.value = res.data.key
+        await getProfile()
       })
       .catch(err => console.log(err))
+  }
+
+  const getProfile = async () => {
+    if (!token.value) return
+
+    try {
+      const response = await axios({
+        method: 'get',
+        url: `${API_URL}/accounts/profile/`,
+        headers: {
+          Authorization: `Token ${token.value}`
+        }
+      })
+      
+      user.value = response.data
+      console.log('유저 정보 로드 완료:', user.value)
+      return response.data
+    } catch (error) {
+      console.error('유저 정보 로드 실패:', error)
+      throw error
+    }
   }
 
   const logOut = function () {
@@ -53,6 +77,7 @@ export const useAccountStore = defineStore('account', () => {
       .then((res) => {
         console.log('로그아웃이 완료되었습니다.')
         token.value = null
+        user.value = null
         router.push({ name: 'login'})
       })
       .catch((err) => console.log(err))
@@ -64,7 +89,7 @@ export const useAccountStore = defineStore('account', () => {
 
   const updateProfile = function (payload) {
     return axios({
-      method: 'patch',
+      method: 'put',
       url: `${API_URL}/accounts/onboarding/`,
       data: payload,
       headers: {
@@ -82,14 +107,16 @@ export const useAccountStore = defineStore('account', () => {
   return { 
     API_URL,
     token,
+    user,
     signUp,
     logIn,
     logOut,
+    getProfile,
     isAuthenticated,
     updateProfile,
    }
 }, {
   persist: {
-    paths: ['token']
+    paths: ['token', 'user']
   }
 })

--- a/frontend/src/stores/moathon.js
+++ b/frontend/src/stores/moathon.js
@@ -1,11 +1,18 @@
 import { ref, computed } from 'vue'
 import { defineStore } from 'pinia'
 import axios from 'axios'
+import { useAccountStore } from '@/stores/accounts'
+import { useRouter } from 'vue-router'
 
 export const useMoathonStore = defineStore('moathon', () => {
+  const accountStore = useAccountStore()
+  const router = useRouter()
   const API_URL = import.meta.env.VITE_API_URL
 
-  const moathons = ref([])         // 화면에 보여줄 모아톤 리스트 (누적됨)
+  const moathons = ref([])
+  const recommendationResult = ref(null) // 추천된 상품 목록 저장
+  const isRecommending = ref(false)   // 추천 로딩 상태
+
   const count = ref(0)             // 전체 개수
   const currentPage = ref(1)      // 현재 페이지 번호
   const itemsPerPage = 24         // 페이지당 개수 설정
@@ -34,12 +41,56 @@ export const useMoathonStore = defineStore('moathon', () => {
     }
   }
 
+  const createMoathon = async (payload) => {
+    try {
+      const response = await axios({
+        method: 'post',
+        url: `${API_URL}/moathons/create/`,
+        data: payload,
+        headers: {
+          Authorization: `Token ${accountStore.token}`,
+        }
+      })
+      router.push({ name: 'moathonDetail', params: { id: response.data.id } })
+      return response.data
+    } catch (error) {
+      console.error('모아톤 생성 실패:', error)
+      throw error
+    }
+  }
+
+  const recommendProduct = async (payload) => {
+    isRecommending.value = true
+    recommendationResult.value = null
+    try {
+      const response = await axios({
+        method: 'post',
+        url: `${API_URL}/recommendations/recommend_product/`,
+        data: payload,
+        headers: {
+          Authorization: `Token ${accountStore.token}`
+        }
+      })
+      recommendationResult.value = response.data
+      return response.data
+    } catch (error) {
+      console.error('추천 요청 실패:', error)
+      throw error
+    } finally {
+      isRecommending.value = false
+    }
+  }
+
   return { 
     moathons, 
     count, 
     currentPage, 
     itemsPerPage,
     totalPages, 
+    recommendationResult,
+    isRecommending,
     fetchMoathons,
+    createMoathon,
+    recommendProduct,
    }
 })

--- a/frontend/src/views/moathon/MoathonCreateView.vue
+++ b/frontend/src/views/moathon/MoathonCreateView.vue
@@ -1,13 +1,79 @@
 <template>
-  <div>
-    <h1>모아톤 시작하기/추가하기 페이지</h1>
+  <div class="create-view">
+    <div class="header">
+      <h1>🚩 모아톤 시작하기</h1>
+      <p>선택하신 금융 상품으로 모아톤을 시작합니다.</p>
+    </div>
+
+    <div class="card">
+      <div class="selected-product-info">
+        <p>선택된 상품 ID: <strong>{{ productId }}</strong></p>
+      </div>
+
+      <MoathonCreateForm :is-submitting="isSubmitting" @submit="handleCreate" />
+    </div>
   </div>
 </template>
 
 <script setup>
+import { ref, computed } from 'vue'
+import { useRoute } from 'vue-router'
+import { useMoathonStore } from '@/stores/moathon'
+import MoathonCreateForm from '@/components/moathon/MoathonCreateForm.vue'
 
+const route = useRoute()
+const store = useMoathonStore()
+
+const isSubmitting = ref(false)
+const productId = computed(() => route.query.productId)
+
+const handleCreate = async (formData) => {
+  if (!productId.value) {
+    alert('잘못된 접근입니다. 상품 정보가 없습니다.')
+    return
+  }
+
+  isSubmitting.value = true
+  try {
+    // 폼 데이터 + 쿼리 파라미터의 상품 ID 결합
+    const payload = {
+      ...formData,
+      product_option: Number(productId.value)
+    }
+    await store.createMoathon(payload)
+  } catch (error) {
+    alert('모아톤 생성에 실패했습니다.')
+  } finally {
+    isSubmitting.value = false
+  }
+}
 </script>
 
 <style scoped>
+.create-view {
+  max-width: 600px;
+  margin: 0 auto;
+  padding: 40px 20px;
+}
 
+.header {
+  text-align: center;
+  margin-bottom: 30px;
+}
+
+.card {
+  background: white;
+  padding: 30px;
+  border-radius: 16px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.05);
+}
+
+.selected-product-info {
+  background: #f8f9fa;
+  padding: 15px;
+  border-radius: 8px;
+  margin-bottom: 20px;
+  text-align: center;
+  color: #666;
+}
 </style>

--- a/frontend/src/views/moathon/MoathonRecommendView.vue
+++ b/frontend/src/views/moathon/MoathonRecommendView.vue
@@ -1,0 +1,149 @@
+<template>
+  <div class="recommend-view">
+    <div class="header">
+      <h1>모아톤 추천받기</h1>
+      <p>저축 목표를 입력하고 맞춤 상품을 추천받아 보세요.</p>
+    </div>
+
+    <div v-if="!store.recommendationResult" class="card fade-in">
+      <MoathonRecommendForm :is-loading="store.isRecommending" @submit="handleRecommend" />
+    </div>
+
+    <div v-else class="result-section fade-in">
+      <MoathonRecommendCard :detail="detail" :warnings="warnings" @create="createWithProduct"
+        @retry="resetRecommendation" />
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref, onMounted, computed } from 'vue'
+import { useRouter } from 'vue-router'
+import { useMoathonStore } from '@/stores/moathon'
+import { useAccountStore } from '@/stores/accounts'
+import MoathonRecommendForm from '@/components/moathon/MoathonRecommendForm.vue'
+import MoathonRecommendCard from '@/components/moathon/MoathonRecommendCard.vue'
+
+const router = useRouter()
+const store = useMoathonStore()
+const accountStore = useAccountStore()
+
+const savedFormData = ref(null)
+
+const detail = computed(() => {
+  return store.recommendationResult?.final_recommendation?.option_detail || {}
+})
+
+const warnings = computed(() => {
+  return store.recommendationResult?.final_recommendation?.warnings || []
+})
+
+// 1. 프로필 정보 확인 (onMounted)
+onMounted(async () => {
+  if (!accountStore.user) {
+    try { await accountStore.getProfile() } catch (e) { }
+  }
+  const user = accountStore.user
+  if (!user || !user.salary || !user.assets || !user.tender) {
+    alert('정확한 상품 추천을 위해 프로필 정보를 먼저 설정해주세요.')
+    router.replace({ name: 'mypage' })
+  }
+})
+
+// 2. 추천 요청 핸들러
+const handleRecommend = async (formData) => {
+  savedFormData.value = { ...formData }
+  try {
+    await store.recommendProduct(formData)
+  } catch (error) {
+    alert('추천 상품을 불러오지 못했습니다.')
+  }
+}
+
+// 3. '이걸로 시작' 핸들러 (바로 생성)
+const createWithProduct = async () => {
+  if (!detail.value || !detail.value.product_name) {
+    alert('상품 정보가 올바르지 않습니다. 다시 시도해주세요.')
+    return
+  }
+
+  if (!confirm(`[${detail.value.product_name}] 상품으로 모아톤을 시작하시겠습니까?`)) return
+
+  if (!savedFormData.value) {
+    alert('입력 정보가 만료되었습니다. 다시 추천을 받아주세요.')
+    resetRecommendation()
+    return
+  }
+
+  try {
+    const payload = {
+      // title: savedFormData.value.title,
+      purpose: savedFormData.value.purpose,
+      target_amount: savedFormData.value.target_amount,
+      start_amount: savedFormData.value.start_amount,
+      product_option: detail.value.option_id 
+    }
+
+    await store.createMoathon(payload)
+    resetRecommendation()
+  } catch (error) {
+    alert('모아톤 생성 중 오류가 발생했습니다.')
+  }
+}
+
+// 4. '다시 추천 받기' 핸들러 (초기화)
+const resetRecommendation = () => {
+  store.recommendationResult = null
+  savedFormData.value = null
+  window.scrollTo({ top: 0, behavior: 'smooth' })
+}
+</script>
+
+<style scoped>
+/* View는 레이아웃과 컨테이너 스타일만 유지 */
+.recommend-view {
+  max-width: 600px;
+  margin: 0 auto;
+  padding: 40px 20px;
+}
+
+.header {
+  text-align: center;
+  margin-bottom: 30px;
+}
+
+.card {
+  background: white;
+  padding: 30px;
+  border-radius: 20px;
+  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.05);
+}
+
+.result-header {
+  text-align: center;
+  margin-bottom: 20px;
+}
+
+.result-header h2 {
+  font-size: 1.4rem;
+  color: #2c3e50;
+  margin-bottom: 8px;
+}
+
+/* 애니메이션 */
+.fade-in {
+  animation: fadeIn 0.5s ease-out;
+}
+
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+    transform: translateY(10px);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+</style>


### PR DESCRIPTION
## 💡 개요 (Overview)
모아톤을 만드는 두 가지 핵심 프로세스(**상품 추천**, **직접 생성**)를 구현했습니다.
또한 추천 정확도를 위해 유저 프로필 유효성 검사를 추가하고, 백엔드 모델의 사소한 버그를 수정했습니다.

## 📃 작업 내용 (Details)
### 1. 모아톤 추천 (Recommend)
- **경로**: `/moathon/recommend`
- **흐름**:
  1. 페이지 진입 시 `accountStore.user`를 확인하여 필수 정보(자산, 연봉 등)가 없으면 마이페이지로 보냅니다.
  2. `MoathonRecommendForm`에서 목표/기간 등을 입력받아 API를 호출합니다.
  3. 응답받은 데이터(추천 사유, 유의사항 포함)를 `MoathonRecommendCard` 컴포넌트를 통해 보여줍니다.
  4. '이걸로 시작하기'를 누르면 즉시 모아톤이 생성됩니다.

### 2. 다이렉트 생성 (Create)
- **경로**: `/moathon/create?productId={id}`
- **흐름**: 금융 상품 상세 페이지에서 진입하며, 별도의 상품 선택 없이 제목/목적만 입력하면 바로 생성됩니다.

## 🔗 관련 이슈 (Links)
- Closes #47 

## 📸 스크린샷 (Screenshots)
### 모아톤 추천
<img width="1277" height="923" alt="image" src="https://github.com/user-attachments/assets/51bc3ee5-fa3e-4274-83c2-c8fcf2b8c138" />
<img width="1278" height="1254" alt="image" src="https://github.com/user-attachments/assets/244d6f6d-aa48-43c5-a226-6bccaec8a0e6" />
<img width="1267" height="1280" alt="image" src="https://github.com/user-attachments/assets/f25de44e-8c92-4a3b-960c-f1df4d3fb2d2" />

### 다이렉트 생성
<img width="945" height="1060" alt="image" src="https://github.com/user-attachments/assets/7c3c432e-6eb1-4314-92a0-a1fc2cb7a66d" />
<img width="939" height="464" alt="image" src="https://github.com/user-attachments/assets/2ca1db6e-fbe5-4060-b348-c820e27fa534" />


## 🎸 기타 사항 & 트러블 슈팅 (Notes)
- **이슈**: 모아톤 제목 자동 생성 시 `<User object>`가 문자열로 박히는 문제 발견
- **해결**: `models.py`의 `save` 메서드 내에서 `self.user.nickname`을 동적으로 가져오도록 수정하여 `"길동's moathon"` 처럼 저장되게 변경했습니다.
