### PR TITLE
[FEAT] 금융 상품 조회 (필터링, 정렬) 및 상세 페이지 생성

### DIFF
--- a/backend/products/views.py
+++ b/backend/products/views.py
@@ -39,7 +39,7 @@ def product_list(request):
         products = products.filter(options__save_trm=save_trm).distinct()
     
     paginator = PageNumberPagination()
-    paginator.page_size = 50
+    paginator.page_size = 24
     result_page = paginator.paginate_queryset(products, request)
 
     if result_page is not None:

--- a/frontend/src/components/common/Navbar.vue
+++ b/frontend/src/components/common/Navbar.vue
@@ -16,7 +16,7 @@
           <RouterLink class="nav-link" :to="{ name: 'videoSearch' }">종목 검색</RouterLink>
           <RouterLink class="nav-link" :to="{ name: 'commodity' }">금/은 시세</RouterLink>
           <RouterLink class="nav-link" :to="{ name: 'bank' }">은행 찾기</RouterLink>
-          <RouterLink class="nav-link" :to="{ name: 'commodity' }">현물 시세</RouterLink>
+          <RouterLink class="nav-link" :to="{ name: 'products' }">금융 상품 찾기</RouterLink>
 
           <template v-if="!accountStore.isAuthenticated">
             <RouterLink class="nav-link" :to="{ name: 'login' }">LOGIN</RouterLink>

--- a/frontend/src/components/common/Pagination.vue
+++ b/frontend/src/components/common/Pagination.vue
@@ -1,0 +1,131 @@
+<template>
+  <div class="pagination" v-if="totalPages > 0">
+    <button 
+      :disabled="currentPage <= 1" 
+      @click="onPageChange(currentPage - 1)" 
+      class="page-btn prev"
+    >
+      &lt;
+    </button>
+
+    <button 
+      v-for="page in pageNumbers" 
+      :key="page" 
+      class="page-btn number"
+      :class="{ active: currentPage === page }"
+      @click="onPageChange(page)"
+    >
+      {{ page }}
+    </button>
+
+    <button 
+      :disabled="currentPage >= totalPages" 
+      @click="onPageChange(currentPage + 1)" 
+      class="page-btn next"
+    >
+      &gt;
+    </button>
+  </div>
+</template>
+
+<script setup>
+import { computed } from 'vue'
+
+// 부모로부터 받아야 할 데이터
+const props = defineProps({
+  currentPage: {
+    type: Number,
+    required: true
+  },
+  totalCount: {
+    type: Number,
+    required: true
+  },
+  itemsPerPage: {
+    type: Number,
+    default: 10 // 기본값 10개
+  },
+  displayPageCount: {
+    type: Number,
+    default: 5 // 한 번에 보여줄 페이지 번호 개수 (예: 1 2 3 4 5)
+  }
+})
+
+// 부모에게 알릴 이벤트
+const emit = defineEmits(['change-page'])
+
+// 전체 페이지 수 계산
+const totalPages = computed(() => {
+  return Math.ceil(props.totalCount / props.itemsPerPage)
+})
+
+// 보여줄 페이지 번호 배열 계산 (예: [1, 2, 3, 4, 5])
+const pageNumbers = computed(() => {
+  const pages = []
+  const half = Math.floor(props.displayPageCount / 2)
+  
+  // 현재 페이지를 중심으로 범위 계산
+  let start = Math.max(1, props.currentPage - half)
+  let end = Math.min(totalPages.value, start + props.displayPageCount - 1)
+
+  // 끝부분이 모자라면 앞부분을 더 채움
+  if (end - start + 1 < props.displayPageCount) {
+    start = Math.max(1, end - props.displayPageCount + 1)
+  }
+
+  for (let i = start; i <= end; i++) {
+    pages.push(i)
+  }
+  return pages
+})
+
+// 페이지 변경 요청
+const onPageChange = (page) => {
+  if (page < 1 || page > totalPages.value) return
+  emit('change-page', page)
+}
+</script>
+
+<style scoped>
+.pagination {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 8px;
+  margin-top: 30px;
+}
+
+.page-btn {
+  min-width: 40px;
+  height: 40px;
+  padding: 0 12px;
+  border: 1px solid #ddd;
+  background: white;
+  border-radius: 8px;
+  font-weight: 600;
+  color: #555;
+  cursor: pointer;
+  transition: all 0.2s;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.page-btn:hover:not(:disabled) {
+  background: #f8f9fa;
+  border-color: #bbb;
+}
+
+.page-btn.active {
+  background: #2c3e50;
+  color: white;
+  border-color: #2c3e50;
+}
+
+.page-btn:disabled {
+  background: #f5f5f5;
+  color: #ccc;
+  cursor: not-allowed;
+  border-color: #eee;
+}
+</style>

--- a/frontend/src/components/product/ProductCard.vue
+++ b/frontend/src/components/product/ProductCard.vue
@@ -1,0 +1,81 @@
+<template>
+  <div class="product-card" @click="handleClick">
+    <div class="card-top">
+      <span class="bank-name">{{ product.bank_name }}</span>
+      <h3 class="product-name">{{ product.fin_prdt_nm }}</h3>
+      
+      <div class="rate-info" v-if="product.max_rate">
+        <span class="label">최고 연</span>
+        <span class="rate">{{ product.max_rate }}%</span>
+      </div>
+    </div>
+
+    <div class="card-bottom">
+      <span class="type-badge" :class="product.product_type">
+        {{ product.product_type === 'DEPOSIT' ? '예금' : '적금' }}
+      </span>
+      <span class="join-way">{{ parseJoinWay(product.join_way) }}</span>
+    </div>
+  </div>
+</template>
+
+<script setup>
+const props = defineProps({
+  product: {
+    type: Object,
+    required: true
+  }
+})
+
+const emit = defineEmits(['click'])
+
+const handleClick = () => {
+  emit('click')
+}
+
+const parseJoinWay = (way) => {
+  if (!way) return ''
+  return way.split(',')[0] + (way.includes(',') ? ' 등' : '')
+}
+</script>
+
+<style scoped>
+.product-card {
+  background: white;
+  border: 1px solid #eee;
+  border-radius: 16px;
+  padding: 24px;
+  cursor: pointer;
+  transition: all 0.2s;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  min-height: 180px;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.03);
+}
+
+.product-card:hover {
+  transform: translateY(-5px);
+  box-shadow: 0 8px 16px rgba(0,0,0,0.1);
+  border-color: #2c3e50;
+}
+
+.card-top { margin-bottom: 20px; }
+
+.bank-name { font-size: 0.9rem; color: #666; margin-bottom: 8px; display: block; font-weight: 500; }
+.product-name { font-size: 1.25rem; font-weight: bold; color: #333; margin: 0 0 12px 0; line-height: 1.4; }
+
+.rate-info { display: flex; align-items: baseline; gap: 4px; margin-top: 5px; }
+.rate-info .label { font-size: 0.85rem; color: #666; }
+.rate-info .rate { font-size: 1.4rem; font-weight: 800; color: #e74c3c; }
+
+.card-bottom { display: flex; justify-content: space-between; align-items: center; margin-top: 15px; }
+
+.type-badge { 
+  display: inline-block; padding: 6px 12px; border-radius: 20px; font-size: 0.8rem; font-weight: 600;
+}
+.type-badge.DEPOSIT { background-color: #e3f2fd; color: #1565c0; }
+.type-badge.SAVING { background-color: #f3e5f5; color: #7b1fa2; }
+
+.join-way { font-size: 0.8rem; color: #999; }
+</style>

--- a/frontend/src/components/product/ProductOptionList.vue
+++ b/frontend/src/components/product/ProductOptionList.vue
@@ -1,0 +1,181 @@
+<template>
+  <div class="options-list">
+    <div v-for="option in options" :key="option.id" class="option-card">
+      <div class="opt-content">
+        <div class="badge-group">
+          <span class="badge term">{{ option.save_trm }}개월</span>
+          
+          <span v-if="option.rsrv_type_nm" class="badge type">
+            {{ option.rsrv_type_nm }}
+          </span>
+          
+          <span v-if="option.intr_rate_type_nm" class="badge type">
+            {{ option.intr_rate_type_nm }}
+          </span>
+        </div>
+
+        <div class="rates-wrapper">
+          <div class="rate-item">
+            <span class="label">기본 금리</span>
+            <span class="value basic">{{ option.intr_rate }}%</span>
+          </div>
+          <div class="rate-divider"></div>
+          <div class="rate-item">
+            <span class="label">최고 우대</span>
+            <span class="value max">{{ option.intr_rate2 }}%</span>
+          </div>
+        </div>
+      </div>
+      
+      <div class="opt-action">
+        <button @click="$emit('select-option', option.id)" class="create-btn">
+          이 옵션으로 시작하기
+        </button>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+defineProps({
+  options: {
+    type: Array,
+    required: true,
+    default: () => []
+  }
+})
+
+defineEmits(['select-option'])
+</script>
+
+<style scoped>
+.options-list {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.option-card {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  border: 1px solid #e0e0e0;
+  border-radius: 12px;
+  padding: 24px;
+  background: white;
+  transition: all 0.2s ease;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.02);
+}
+
+.option-card:hover {
+  border-color: #2c3e50;
+  box-shadow: 0 4px 12px rgba(0,0,0,0.08);
+  transform: translateY(-2px);
+}
+
+/* 좌측 콘텐츠 영역 */
+.opt-content {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+/* 뱃지 스타일 */
+.badge-group {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.badge {
+  padding: 4px 10px;
+  border-radius: 6px;
+  font-size: 0.8rem;
+  font-weight: 600;
+}
+
+.badge.term {
+  background-color: #2c3e50;
+  color: white;
+}
+
+.badge.type {
+  background-color: #f1f3f5;
+  color: #495057;
+  border: 1px solid #dee2e6;
+}
+
+/* 금리 정보 스타일 */
+.rates-wrapper {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+}
+
+.rate-item {
+  display: flex;
+  align-items: baseline;
+  gap: 6px;
+}
+
+.rate-item .label {
+  font-size: 0.9rem;
+  color: #868e96;
+}
+
+.rate-item .value {
+  font-size: 1.1rem;
+  font-weight: 700;
+  font-family: 'Roboto', sans-serif; /* 숫자 가독성 */
+}
+
+.value.basic {
+  color: #343a40;
+}
+
+.value.max {
+  color: #e74c3c;
+  font-size: 1.25rem;
+}
+
+.rate-divider {
+  width: 1px;
+  height: 14px;
+  background-color: #dee2e6;
+}
+
+/* 버튼 스타일 */
+.create-btn {
+  background: #2c3e50;
+  color: white;
+  border: none;
+  padding: 12px 20px;
+  border-radius: 8px;
+  font-weight: 700;
+  cursor: pointer;
+  transition: background 0.2s;
+  white-space: nowrap;
+}
+
+.create-btn:hover {
+  background: #1a252f;
+}
+
+/* 모바일 대응 */
+@media (max-width: 600px) {
+  .option-card {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 20px;
+  }
+  
+  .opt-action {
+    display: flex;
+    justify-content: flex-end;
+  }
+  
+  .create-btn {
+    width: 100%;
+  }
+}
+</style>

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -10,6 +10,8 @@ import MoathonCreateView from '@/views/moathon/MoathonCreateView.vue'
 import MoathonDetailView from '@/views/moathon/MoathonDetailView.vue'
 import MoathonListView from '@/views/moathon/MoathonListView.vue'
 import MoathonRecommendView from '@/views/moathon/MoathonRecommendView.vue'
+import ProductListView from '@/views/product/ProductListView.vue'
+import ProductDetailView from '@/views/product/ProductDetailView.vue'
 import MyPageView from '@/views/user/MyPageView.vue'
 import { createRouter, createWebHistory } from 'vue-router'
 
@@ -98,6 +100,21 @@ const router = createRouter({
       path: '/commodity',
       name: 'commodity',
       component: CommoditySearchView,
+    },
+    {
+      path: '/products',
+      children: [
+        {
+          path: '',
+          name: 'products',
+          component: ProductListView,
+        },
+        {
+          path: ':id',
+          name: 'productDetail',
+          component: ProductDetailView,
+        }
+      ],
     },
   ],
 })

--- a/frontend/src/stores/products.js
+++ b/frontend/src/stores/products.js
@@ -10,6 +10,7 @@ export const useProductStore = defineStore('product', () => {
   const products = ref([])
   const productDetail = ref(null)
   const isLoading = ref(false)
+  const banks = ref([])
 
   const getProducts = async () => {
     // 이미 데이터가 있다면 다시 부르지 않음 (SPA 네비게이션 시 효율성)
@@ -49,5 +50,19 @@ export const useProductStore = defineStore('product', () => {
     }
   }
 
-  return { products, productDetail, getProducts, getProductDetail, isLoading }
+  const getBanks = async () => {
+    if (banks.value.length > 0) return
+
+    try {
+      const response = await axios ({
+        method: 'get',
+        url: `${API_URL}/products/banklist/`,
+      })
+      banks.value = response.data
+    } catch (error) {
+      console.error('은행 목록 조회 실패:', error)
+    }
+  }
+
+  return { products, productDetail, getProducts, getProductDetail, isLoading, banks, getBanks }
 })

--- a/frontend/src/stores/products.js
+++ b/frontend/src/stores/products.js
@@ -1,0 +1,53 @@
+import { ref } from 'vue'
+import { defineStore } from 'pinia'
+import axios from 'axios'
+import { useAccountStore } from '@/stores/accounts'
+
+export const useProductStore = defineStore('product', () => {
+  const accountStore = useAccountStore()
+  const API_URL = import.meta.env.VITE_API_URL
+
+  const products = ref([])
+  const productDetail = ref(null)
+  const isLoading = ref(false)
+
+  const getProducts = async () => {
+    // 이미 데이터가 있다면 다시 부르지 않음 (SPA 네비게이션 시 효율성)
+    if (products.value.length > 0) return
+
+    isLoading.value = true
+    let allResults = []
+    let nextUrl = `${API_URL}/products/`
+
+    try {
+      while (nextUrl) {
+        const response = await axios.get(nextUrl)
+        const data = response.data
+        allResults = [...allResults, ...data.results]
+        nextUrl = data.next
+      }
+      products.value = allResults
+    } catch (err) {
+      console.error('상품 로딩 실패:', err)
+    } finally {
+      isLoading.value = false
+    }
+  }
+
+  const getProductDetail = async (id) => {
+    try {
+      const response = await axios({
+        method: 'get',
+        url: `${API_URL}/products/${id}/`,
+        headers: {
+          Authorization: `Token ${accountStore.token}`,
+        },
+      })
+      productDetail.value = response.data
+    } catch (error) {
+      console.error('상품 상세 조회 실패:', error)
+    }
+  }
+
+  return { products, productDetail, getProducts, getProductDetail, isLoading }
+})

--- a/frontend/src/views/moathon/MoathonListView.vue
+++ b/frontend/src/views/moathon/MoathonListView.vue
@@ -21,48 +21,14 @@
       <p>등록된 모아톤이 없습니다.</p>
     </div>
 
-    <div class="pagination" v-if="store.totalPages > 1">
-      <button 
-        :disabled="store.currentPage === 1" 
-        @click="changePage(1)"
-        class="page-btn nav-btn"
-      >
-        &lt;&lt;
-      </button>
-
-      <button 
-        :disabled="store.currentPage === 1" 
-        @click="changePage(store.currentPage - 1)"
-        class="page-btn nav-btn"
-      >
-        &lt;
-      </button>
-
-      <button 
-        v-for="page in visiblePages" 
-        :key="page"
-        @click="changePage(page)"
-        class="page-btn number-btn"
-        :class="{ active: page === store.currentPage }"
-      >
-        {{ page }}
-      </button>
-
-      <button 
-        :disabled="store.currentPage === store.totalPages" 
-        @click="changePage(store.currentPage + 1)"
-        class="page-btn nav-btn"
-      >
-        &gt;
-      </button>
-
-      <button 
-        :disabled="store.currentPage === store.totalPages" 
-        @click="changePage(store.totalPages)"
-        class="page-btn nav-btn"
-      >
-        &gt;&gt;
-      </button>
+    <div class="pagination-wrapper" v-if="store.count > 0">
+      <Pagination
+        :current-page="store.currentPage"
+        :total-count="store.count"
+        :items-per-page="12"
+        :display-page-count="5"
+        @change-page="handlePageChange"
+      />
     </div>
   </div>
 </template>
@@ -72,40 +38,15 @@ import { onMounted, computed } from 'vue'
 import { RouterLink } from 'vue-router'
 import { useMoathonStore } from '@/stores/moathon'
 import MoathonCard from '@/components/moathon/MoathonCard.vue'
+import Pagination from '@/components/common/Pagination.vue'
 
 const store = useMoathonStore()
 
 // 페이지 변경 핸들러
-const changePage = (page) => {
-  if (page >= 1 && page <= store.totalPages) {
-    store.fetchMoathons(page)
-    window.scrollTo({ top: 0, behavior: 'smooth' })
-  }
+const handlePageChange = (page) => {
+  store.fetchMoathons(page)
+  window.scrollTo({ top: 0, behavior: 'smooth' })
 }
-
-// 화면에 보여줄 페이지 번호 계산 (최대 5개씩 노출)
-const visiblePages = computed(() => {
-  const current = store.currentPage
-  const total = store.totalPages
-  const maxVisible = 5
-  
-  let start = current - Math.floor(maxVisible / 2)
-  start = Math.max(start, 1)
-  
-  let end = start + maxVisible - 1
-  end = Math.min(end, total)
-
-  // 끝 부분 보정 (예: 총 10페이지인데 현재 9페이지면 6,7,8,9,10 보여줌)
-  if (end - start + 1 < maxVisible) {
-    start = Math.max(end - maxVisible + 1, 1)
-  }
-
-  const pages = []
-  for (let i = start; i <= end; i++) {
-    pages.push(i)
-  }
-  return pages
-})
 
 onMounted(() => {
   store.fetchMoathons(1)
@@ -134,14 +75,17 @@ onMounted(() => {
   text-decoration: none;
   border-radius: 30px;
   font-weight: bold;
+  transition: background-color 0.2s;
 }
 
-/* 그리드 레이아웃 수정 */
+.create-btn:hover {
+  background-color: #1a252f;
+}
+
+/* 그리드 레이아웃 */
 .moathon-grid {
   display: grid;
-  gap: 20px; /* 카드 간격 24px -> 20px로 조금 좁힘 */
-  
-  /* 기본(모바일): 1열 */
+  gap: 20px; 
   grid-template-columns: repeat(1, 1fr);
 }
 
@@ -159,7 +103,7 @@ onMounted(() => {
   }
 }
 
-/* 데스크탑: 4열 (최대 4개) */
+/* 데스크탑: 4열 */
 @media (min-width: 1280px) {
   .moathon-grid {
     grid-template-columns: repeat(4, 1fr);
@@ -172,50 +116,9 @@ onMounted(() => {
   color: #888;
 }
 
-/* 페이지네이션 스타일 (기존 유지) */
-.pagination {
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  gap: 8px;
+.pagination-wrapper {
   margin-top: 50px;
-}
-
-.page-btn {
-  background: white;
-  border: 1px solid #ddd;
-  min-width: 36px; /* 버튼 크기 살짝 조정 */
-  height: 36px;
-  border-radius: 8px;
-  cursor: pointer;
-  font-size: 0.9rem;
-  color: #555;
-  transition: all 0.2s;
   display: flex;
-  align-items: center;
   justify-content: center;
-}
-
-.page-btn:hover:not(:disabled) {
-  background-color: #f0f0f0;
-  border-color: #bbb;
-}
-
-.page-btn:disabled {
-  cursor: not-allowed;
-  opacity: 0.5;
-  background-color: #f9f9f9;
-}
-
-.page-btn.active {
-  background-color: #2c3e50;
-  color: white;
-  border-color: #2c3e50;
-  font-weight: bold;
-}
-
-.nav-btn {
-  font-weight: bold;
-  color: #888;
 }
 </style>

--- a/frontend/src/views/product/ProductDetailView.vue
+++ b/frontend/src/views/product/ProductDetailView.vue
@@ -1,0 +1,93 @@
+<template>
+  <div class="detail-container" v-if="product">
+    <div class="product-info-section">
+      <span class="bank-badge">{{ product.kor_co_nm }}</span>
+      <h1 class="title">{{ product.fin_prdt_nm }}</h1>
+      
+      <div class="info-grid">
+        <div class="info-item">
+          <h4>가입 방법</h4>
+          <p>{{ product.join_way || '영업점, 인터넷, 스마트폰' }}</p>
+        </div>
+        <div class="info-item">
+          <h4>가입 대상</h4>
+          <p>{{ product.join_member || '실명의 개인' }}</p>
+        </div>
+        <div class="info-item full-width" v-if="product.etc_note">
+          <h4>유의 사항</h4>
+          <p>{{ product.etc_note }}</p>
+        </div>
+      </div>
+    </div>
+
+    <hr class="divider" />
+
+    <div class="options-section">
+      <h2>금리 및 기간 옵션</h2>
+      <p class="desc">원하는 조건을 선택하여 저축 챌린지를 시작해보세요.</p>
+
+      <ProductOptionList 
+        v-if="product.options && product.options.length > 0"
+        :options="product.options" 
+        @select-option="goMoathonCreate"
+      />
+      
+      <div v-else class="empty-options">
+        <p>상세 옵션 정보가 없습니다.</p>
+      </div>
+    </div>
+  </div>
+
+  <div v-else class="loading">
+    <p>상품 정보를 불러오는 중입니다...</p>
+  </div>
+</template>
+
+<script setup>
+import { computed, onMounted } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+import { useProductStore } from '@/stores/products'
+import ProductOptionList from '@/components/product/ProductOptionList.vue'
+
+const store = useProductStore()
+const route = useRoute()
+const router = useRouter()
+
+const product = computed(() => store.productDetail)
+
+onMounted(() => {
+  store.getProductDetail(route.params.id)
+})
+
+const goMoathonCreate = (optionId) => {
+  router.push({ 
+    name: 'moathonCreate', 
+    query: { productId: optionId } 
+  })
+}
+</script>
+
+<style scoped>
+.detail-container { max-width: 800px; margin: 0 auto; padding: 40px 20px; }
+.loading { text-align: center; padding: 50px; color: #888; }
+
+/* 상품 기본 정보 스타일 유지 */
+.product-info-section { text-align: center; margin-bottom: 30px; }
+.bank-badge { background: #e3f2fd; color: #1565c0; padding: 6px 12px; border-radius: 20px; font-weight: bold; font-size: 0.9rem; }
+.title { font-size: 2rem; margin: 16px 0 30px; color: #333; }
+
+.info-grid { 
+  display: grid; grid-template-columns: 1fr 1fr; gap: 20px; 
+  background: #f8f9fa; padding: 24px; border-radius: 16px; text-align: left; 
+}
+.info-item h4 { font-size: 0.9rem; color: #666; margin-bottom: 8px; }
+.info-item p { font-size: 1rem; color: #333; line-height: 1.5; }
+.full-width { grid-column: 1 / -1; }
+
+.divider { border: 0; height: 1px; background: #eee; margin: 40px 0; }
+
+/* 옵션 섹션 헤더 스타일 */
+.options-section h2 { margin-bottom: 8px; color: #2c3e50; }
+.desc { color: #666; margin-bottom: 24px; }
+.empty-options { color: #888; text-align: center; padding: 20px; }
+</style>

--- a/frontend/src/views/product/ProductListView.vue
+++ b/frontend/src/views/product/ProductListView.vue
@@ -1,0 +1,225 @@
+<template>
+  <div class="product-list-container">
+    <div class="header">
+      <h1>🏦 금융 상품 찾기</h1>
+      <p>나에게 딱 맞는 예/적금 상품을 찾아보세요.</p>
+    </div>
+
+    <div class="tabs-wrapper mb-4">
+      <ul class="nav nav-pills justify-content-center">
+        <li class="nav-item">
+          <a class="nav-link" :class="{ active: filters.type === 'ALL' }" @click.prevent="filters.type = 'ALL'" href="#">전체</a>
+        </li>
+        <li class="nav-item">
+          <a class="nav-link" :class="{ active: filters.type === 'DEPOSIT' }" @click.prevent="filters.type = 'DEPOSIT'" href="#">정기예금</a>
+        </li>
+        <li class="nav-item">
+          <a class="nav-link" :class="{ active: filters.type === 'SAVING' }" @click.prevent="filters.type = 'SAVING'" href="#">정기적금</a>
+        </li>
+      </ul>
+    </div>
+
+    <div class="filter-bar">
+      <select v-model="filters.bank" class="form-select bank-select">
+        <option value="">전체 은행</option>
+        <option v-for="bank in bankList" :key="bank" :value="bank">
+          {{ bank }}
+        </option>
+      </select>
+
+      <select v-model="filters.period" class="form-select period-select">
+        <option value="">전체 기간</option>
+        <option value="6">6개월</option>
+        <option value="12">12개월</option>
+        <option value="24">24개월</option>
+        <option value="36">36개월</option>
+      </select>
+    </div>
+
+    <div v-if="store.isLoading" class="loading-state">
+      <div class="spinner-border text-primary" role="status"></div>
+      <p class="mt-2">모든 상품 정보를 불러오는 중입니다...</p>
+    </div>
+
+    <div v-else>
+      <div class="header-info mb-3">
+        <span class="badge bg-secondary">{{ filteredProducts.length }}개의 상품</span>
+        <span v-if="filters.period" class="ms-2 text-primary small">
+          * {{ filters.period }}개월 금리 기준 정렬됨
+        </span>
+        <span v-else class="ms-2 text-primary small">
+          * 최고 우대 금리 기준 정렬됨
+        </span>
+      </div>
+
+      <div v-if="filteredProducts.length > 0">
+        <div class="product-grid">
+          <ProductCard
+            v-for="product in paginatedProducts" 
+            :key="product.id" 
+            :product="product"
+            @click="goDetail(product.id)"
+          />
+        </div>
+
+        <Pagination
+          :current-page="currentPage"
+          :total-count="filteredProducts.length"
+          :items-per-page="itemsPerPage"
+          @change-page="handlePageChange"
+        />
+      </div>
+
+      <div v-else class="empty-state">
+        <p>조건에 맞는 상품이 없습니다.</p>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref, reactive, computed, onMounted, watch } from 'vue'
+import { useRouter } from 'vue-router'
+import { useProductStore } from '@/stores/products'
+import ProductCard from '@/components/product/ProductCard.vue'
+import Pagination from '@/components/common/Pagination.vue'
+
+const store = useProductStore()
+const router = useRouter()
+
+const filters = reactive({
+  type: 'ALL',      // ALL, DEPOSIT, SAVING
+  bank: '',         // 은행명
+  period: ''        // 저장 기간 (문자열 '6', '12' 등)
+})
+
+const currentPage = ref(1)
+const itemsPerPage = 12
+
+// 은행 목록 (하드코딩 예시)
+// TODO: API 호출로 변경
+const bankList = [
+  '우리은행', '한국스탠다드차타드은행', '대구은행', '부산은행', 
+  '광주은행', '제주은행', '전북은행', '경남은행', '중소기업은행', 
+  '한국산업은행', '국민은행', '신한은행', '농협은행', '하나은행', 
+  '케이뱅크', '수협은행', '카카오뱅크', '토스뱅크'
+]
+
+const filteredProducts = computed(() => {
+  let results = store.products
+
+  // 1. 탭 필터 (예금/적금)
+  if (filters.type !== 'ALL') {
+    results = results.filter(p => p.product_type === filters.type)
+  }
+
+  // 2. 은행 필터
+  if (filters.bank) {
+    results = results.filter(p => p.bank_name === filters.bank)
+  }
+
+  // 3. 기간 필터 (선택한 기간 옵션이 있는 상품만)
+  if (filters.period) {
+    results = results.filter(p => 
+      p.options.some(opt => opt.save_trm === filters.period)
+    )
+  }
+
+  // 4. 정렬 (최고 금리순)
+  // 원본 보호를 위해 복사본([...]) 생성 후 정렬
+  return [...results].sort((a, b) => {
+    let rateA, rateB
+
+    if (filters.period) {
+      // 기간이 선택되었으면, 해당 기간의 우대금리(intr_rate2)를 찾아 비교
+      const optA = a.options.find(o => o.save_trm === filters.period)
+      const optB = b.options.find(o => o.save_trm === filters.period)
+      // 해당 기간 옵션이 없으면 -1 (맨 뒤로 보냄)
+      rateA = optA ? optA.intr_rate2 : -1
+      rateB = optB ? optB.intr_rate2 : -1
+    } else {
+      // 기간 선택 없으면 상품 자체의 최고 우대 금리(max_rate) 사용
+      rateA = a.max_rate
+      rateB = b.max_rate
+    }
+    
+    // 내림차순 정렬
+    return rateB - rateA
+  })
+})
+
+// [페이지네이션] 현재 페이지에 보여줄 데이터 슬라이싱
+const paginatedProducts = computed(() => {
+  const start = (currentPage.value - 1) * itemsPerPage
+  const end = start + itemsPerPage
+  return filteredProducts.value.slice(start, end)
+})
+
+watch(filters, () => {
+  currentPage.value = 1
+})
+
+const handlePageChange = (page) => {
+  currentPage.value = page
+  window.scrollTo({ top: 0, behavior: 'smooth' })
+}
+
+const goDetail = (id) => {
+  router.push({ name: 'productDetail', params: { id } })
+}
+
+onMounted(() => {
+  store.getProducts()
+})
+</script>
+
+<style scoped>
+.product-list-container { max-width: 1200px; margin: 0 auto; padding: 40px 16px; }
+.header { text-align: center; margin-bottom: 30px; }
+
+/* 탭 스타일 */
+.nav-pills .nav-link {
+  color: #666;
+  border-radius: 20px;
+  padding: 8px 24px;
+  margin: 0 4px;
+  font-weight: 600;
+}
+.nav-pills .nav-link.active {
+  background-color: #2c3e50;
+  color: #fff;
+}
+
+/* 필터 바 */
+.filter-bar {
+  display: flex;
+  justify-content: flex-end;
+  gap: 10px;
+  margin-bottom: 20px;
+}
+.form-select {
+  width: auto;
+  min-width: 120px;
+  border-radius: 8px;
+  border-color: #ddd;
+}
+
+.product-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+  gap: 20px;
+  margin-bottom: 40px;
+}
+
+.loading-state, .empty-state {
+  text-align: center;
+  padding: 80px 0;
+  color: #888;
+}
+
+.header-info {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+</style>

--- a/frontend/src/views/product/ProductListView.vue
+++ b/frontend/src/views/product/ProductListView.vue
@@ -22,7 +22,7 @@
     <div class="filter-bar">
       <select v-model="filters.bank" class="form-select bank-select">
         <option value="">전체 은행</option>
-        <option v-for="bank in bankList" :key="bank" :value="bank">
+        <option v-for="bank in store.banks" :key="bank" :value="bank">
           {{ bank }}
         </option>
       </select>
@@ -96,15 +96,6 @@ const filters = reactive({
 const currentPage = ref(1)
 const itemsPerPage = 12
 
-// 은행 목록 (하드코딩 예시)
-// TODO: API 호출로 변경
-const bankList = [
-  '우리은행', '한국스탠다드차타드은행', '대구은행', '부산은행', 
-  '광주은행', '제주은행', '전북은행', '경남은행', '중소기업은행', 
-  '한국산업은행', '국민은행', '신한은행', '농협은행', '하나은행', 
-  '케이뱅크', '수협은행', '카카오뱅크', '토스뱅크'
-]
-
 const filteredProducts = computed(() => {
   let results = store.products
 
@@ -170,6 +161,7 @@ const goDetail = (id) => {
 
 onMounted(() => {
   store.getProducts()
+  store.getBanks()
 })
 </script>
 


### PR DESCRIPTION
## 💡 개요 (Overview)
사용자가 자신에게 맞는 금융 상품을 더 쉽게 찾을 수 있도록 리스트 페이지의 필터링/정렬 기능을 대폭 강화하고, 코드의 재사용성을 높이기 위해 페이지네이션과 상세 페이지 옵션 리스트를 컴포넌트로 분리하였습니다.

## 📃 작업 내용 (Details)
### 1. 공통 컴포넌트 (`Pagination.vue`)
- 기존 `MoathonListView`에 하드코딩되어 있던 페이지네이션 로직을 별도 컴포넌트로 분리했습니다.
- 이제 `ProductListView` 등 다른 곳에서도 쉽게 페이지네이션을 적용할 수 있습니다.

### 2. 금융 상품 리스트 (`ProductListView.vue`)
- **데이터 로딩 방식 변경**: 서버 API 한계(정렬 미지원)를 극복하고 빠른 반응성을 제공하기 위해, 진입 시 전체 데이터를 로드하여 클라이언트 사이드에서 처리하도록 변경했습니다.
- **필터링 기능**: 
  - `예금/적금` 탭 분리
  - `은행명` 필터
  - `가입 기간` (6/12/24/36개월) 필터
- **정렬 로직**: 특정 기간 선택 시, 해당 기간의 우대 금리가 높은 순서대로 정렬되도록 로직을 구현했습니다.

### 3. 상품 상세 페이지 (`ProductDetailView.vue`)
- **컴포넌트 분리**: 비대한 코드를 줄이기 위해 옵션 목록을 `ProductOptionList.vue`로 분리했습니다.
- **정보 추가**: 옵션 카드에 `자유적립식/정액적립식`, `단리/복리` 정보를 뱃지 형태로 추가하여 가독성을 높였습니다.

## 📸 Screenshots
### 금융 상품 전체 조회
| 전체 조회 | 필터링(적금, 24개월) |
| --- | ---|
|<img width="1276" height="1317" alt="image" src="https://github.com/user-attachments/assets/3604ee31-0948-44d3-9970-6ead43dfcc12" />|<img width="1276" height="1164" alt="image" src="https://github.com/user-attachments/assets/a87f98e2-755a-4870-a815-965560a49c0b" />|

### 금융 상품 상세 조회
<img width="1277" height="1204" alt="image" src="https://github.com/user-attachments/assets/d6457931-c796-4e4a-a9f8-f7378ed08cd2" />


## 🔗 관련 이슈 (Links)
- Closes #74 

## 📚 테스트 (Test)
- [ ] 로컬 환경에서 기능 테스트 완료
- [ ] 기존 기능에 영향 없는지 확인 완료