### PR TITLE
[FEAT] fixture 데이터 생성

### DIFF
--- a/backend/accounts/fixtures/accounts/accounts_social.json
+++ b/backend/accounts/fixtures/accounts/accounts_social.json
@@ -1,0 +1,2882 @@
+[
+{
+  "model": "accounts.userbadge",
+  "pk": 1,
+  "fields": {
+    "user": 1,
+    "badge": 5,
+    "moathon": null,
+    "obtained_at": "2025-12-24T02:38:34.761Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 2,
+  "fields": {
+    "user": 2,
+    "badge": 5,
+    "moathon": null,
+    "obtained_at": "2025-12-24T02:38:34.763Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 3,
+  "fields": {
+    "user": 3,
+    "badge": 5,
+    "moathon": null,
+    "obtained_at": "2025-12-24T02:38:34.764Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 4,
+  "fields": {
+    "user": 4,
+    "badge": 5,
+    "moathon": null,
+    "obtained_at": "2025-12-24T02:38:34.765Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 5,
+  "fields": {
+    "user": 5,
+    "badge": 5,
+    "moathon": null,
+    "obtained_at": "2025-12-24T02:38:34.767Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 6,
+  "fields": {
+    "user": 6,
+    "badge": 5,
+    "moathon": null,
+    "obtained_at": "2025-12-24T02:38:34.768Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 7,
+  "fields": {
+    "user": 7,
+    "badge": 5,
+    "moathon": null,
+    "obtained_at": "2025-12-24T02:38:34.769Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 8,
+  "fields": {
+    "user": 8,
+    "badge": 5,
+    "moathon": null,
+    "obtained_at": "2025-12-24T02:38:34.770Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 9,
+  "fields": {
+    "user": 9,
+    "badge": 5,
+    "moathon": null,
+    "obtained_at": "2025-12-24T02:38:34.772Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 10,
+  "fields": {
+    "user": 10,
+    "badge": 5,
+    "moathon": null,
+    "obtained_at": "2025-12-24T02:38:34.773Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 11,
+  "fields": {
+    "user": 11,
+    "badge": 5,
+    "moathon": null,
+    "obtained_at": "2025-12-24T02:38:34.774Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 12,
+  "fields": {
+    "user": 12,
+    "badge": 5,
+    "moathon": null,
+    "obtained_at": "2025-12-24T02:38:34.776Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 13,
+  "fields": {
+    "user": 13,
+    "badge": 5,
+    "moathon": null,
+    "obtained_at": "2025-12-24T02:38:34.777Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 14,
+  "fields": {
+    "user": 14,
+    "badge": 5,
+    "moathon": null,
+    "obtained_at": "2025-12-24T02:38:34.778Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 15,
+  "fields": {
+    "user": 15,
+    "badge": 5,
+    "moathon": null,
+    "obtained_at": "2025-12-24T02:38:34.780Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 16,
+  "fields": {
+    "user": 16,
+    "badge": 5,
+    "moathon": null,
+    "obtained_at": "2025-12-24T02:38:34.781Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 17,
+  "fields": {
+    "user": 17,
+    "badge": 5,
+    "moathon": null,
+    "obtained_at": "2025-12-24T02:38:34.782Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 18,
+  "fields": {
+    "user": 18,
+    "badge": 5,
+    "moathon": null,
+    "obtained_at": "2025-12-24T02:38:34.784Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 19,
+  "fields": {
+    "user": 19,
+    "badge": 5,
+    "moathon": null,
+    "obtained_at": "2025-12-24T02:38:34.785Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 20,
+  "fields": {
+    "user": 20,
+    "badge": 5,
+    "moathon": null,
+    "obtained_at": "2025-12-24T02:38:34.786Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 21,
+  "fields": {
+    "user": 21,
+    "badge": 5,
+    "moathon": null,
+    "obtained_at": "2025-12-24T02:38:34.787Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 22,
+  "fields": {
+    "user": 22,
+    "badge": 5,
+    "moathon": null,
+    "obtained_at": "2025-12-24T02:38:34.789Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 23,
+  "fields": {
+    "user": 23,
+    "badge": 5,
+    "moathon": null,
+    "obtained_at": "2025-12-24T02:38:34.790Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 24,
+  "fields": {
+    "user": 24,
+    "badge": 5,
+    "moathon": null,
+    "obtained_at": "2025-12-24T02:38:34.791Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 25,
+  "fields": {
+    "user": 25,
+    "badge": 5,
+    "moathon": null,
+    "obtained_at": "2025-12-24T02:38:34.793Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 26,
+  "fields": {
+    "user": 26,
+    "badge": 5,
+    "moathon": null,
+    "obtained_at": "2025-12-24T02:38:34.794Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 27,
+  "fields": {
+    "user": 27,
+    "badge": 5,
+    "moathon": null,
+    "obtained_at": "2025-12-24T02:38:34.795Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 28,
+  "fields": {
+    "user": 28,
+    "badge": 5,
+    "moathon": null,
+    "obtained_at": "2025-12-24T02:38:34.797Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 29,
+  "fields": {
+    "user": 29,
+    "badge": 5,
+    "moathon": null,
+    "obtained_at": "2025-12-24T02:38:34.798Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 30,
+  "fields": {
+    "user": 30,
+    "badge": 5,
+    "moathon": null,
+    "obtained_at": "2025-12-24T02:38:34.799Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 31,
+  "fields": {
+    "user": 1,
+    "badge": 6,
+    "moathon": null,
+    "obtained_at": "2025-12-24T02:38:34.800Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 32,
+  "fields": {
+    "user": 2,
+    "badge": 6,
+    "moathon": null,
+    "obtained_at": "2025-12-24T02:38:34.805Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 33,
+  "fields": {
+    "user": 2,
+    "badge": 9,
+    "moathon": null,
+    "obtained_at": "2025-12-24T02:38:34.809Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 34,
+  "fields": {
+    "user": 3,
+    "badge": 6,
+    "moathon": null,
+    "obtained_at": "2025-12-24T02:38:34.811Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 35,
+  "fields": {
+    "user": 4,
+    "badge": 6,
+    "moathon": null,
+    "obtained_at": "2025-12-24T02:38:34.819Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 36,
+  "fields": {
+    "user": 5,
+    "badge": 6,
+    "moathon": null,
+    "obtained_at": "2025-12-24T02:38:34.823Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 37,
+  "fields": {
+    "user": 6,
+    "badge": 6,
+    "moathon": null,
+    "obtained_at": "2025-12-24T02:38:34.829Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 38,
+  "fields": {
+    "user": 7,
+    "badge": 6,
+    "moathon": null,
+    "obtained_at": "2025-12-24T02:38:34.834Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 39,
+  "fields": {
+    "user": 8,
+    "badge": 6,
+    "moathon": null,
+    "obtained_at": "2025-12-24T02:38:34.841Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 40,
+  "fields": {
+    "user": 9,
+    "badge": 6,
+    "moathon": null,
+    "obtained_at": "2025-12-24T02:38:34.845Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 41,
+  "fields": {
+    "user": 10,
+    "badge": 6,
+    "moathon": null,
+    "obtained_at": "2025-12-24T02:38:34.853Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 42,
+  "fields": {
+    "user": 10,
+    "badge": 9,
+    "moathon": null,
+    "obtained_at": "2025-12-24T02:38:34.859Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 43,
+  "fields": {
+    "user": 11,
+    "badge": 6,
+    "moathon": null,
+    "obtained_at": "2025-12-24T02:38:34.862Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 44,
+  "fields": {
+    "user": 12,
+    "badge": 6,
+    "moathon": null,
+    "obtained_at": "2025-12-24T02:38:34.866Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 45,
+  "fields": {
+    "user": 13,
+    "badge": 6,
+    "moathon": null,
+    "obtained_at": "2025-12-24T02:38:34.870Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 46,
+  "fields": {
+    "user": 13,
+    "badge": 9,
+    "moathon": null,
+    "obtained_at": "2025-12-24T02:38:34.875Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 47,
+  "fields": {
+    "user": 14,
+    "badge": 6,
+    "moathon": null,
+    "obtained_at": "2025-12-24T02:38:34.877Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 48,
+  "fields": {
+    "user": 15,
+    "badge": 6,
+    "moathon": null,
+    "obtained_at": "2025-12-24T02:38:34.882Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 49,
+  "fields": {
+    "user": 16,
+    "badge": 6,
+    "moathon": null,
+    "obtained_at": "2025-12-24T02:38:34.888Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 50,
+  "fields": {
+    "user": 16,
+    "badge": 9,
+    "moathon": null,
+    "obtained_at": "2025-12-24T02:38:34.893Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 51,
+  "fields": {
+    "user": 17,
+    "badge": 6,
+    "moathon": null,
+    "obtained_at": "2025-12-24T02:38:34.894Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 52,
+  "fields": {
+    "user": 18,
+    "badge": 6,
+    "moathon": null,
+    "obtained_at": "2025-12-24T02:38:34.899Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 53,
+  "fields": {
+    "user": 19,
+    "badge": 6,
+    "moathon": null,
+    "obtained_at": "2025-12-24T02:38:34.907Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 54,
+  "fields": {
+    "user": 19,
+    "badge": 9,
+    "moathon": null,
+    "obtained_at": "2025-12-24T02:38:34.915Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 55,
+  "fields": {
+    "user": 20,
+    "badge": 6,
+    "moathon": null,
+    "obtained_at": "2025-12-24T02:38:34.916Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 56,
+  "fields": {
+    "user": 21,
+    "badge": 6,
+    "moathon": null,
+    "obtained_at": "2025-12-24T02:38:34.921Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 57,
+  "fields": {
+    "user": 21,
+    "badge": 9,
+    "moathon": null,
+    "obtained_at": "2025-12-24T02:38:34.925Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 58,
+  "fields": {
+    "user": 22,
+    "badge": 6,
+    "moathon": null,
+    "obtained_at": "2025-12-24T02:38:34.928Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 59,
+  "fields": {
+    "user": 23,
+    "badge": 6,
+    "moathon": null,
+    "obtained_at": "2025-12-24T02:38:34.933Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 60,
+  "fields": {
+    "user": 24,
+    "badge": 6,
+    "moathon": null,
+    "obtained_at": "2025-12-24T02:38:34.940Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 61,
+  "fields": {
+    "user": 25,
+    "badge": 6,
+    "moathon": null,
+    "obtained_at": "2025-12-24T02:38:34.945Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 62,
+  "fields": {
+    "user": 26,
+    "badge": 6,
+    "moathon": null,
+    "obtained_at": "2025-12-24T02:38:34.952Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 63,
+  "fields": {
+    "user": 27,
+    "badge": 6,
+    "moathon": null,
+    "obtained_at": "2025-12-24T02:38:34.959Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 64,
+  "fields": {
+    "user": 28,
+    "badge": 6,
+    "moathon": null,
+    "obtained_at": "2025-12-24T02:38:34.967Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 65,
+  "fields": {
+    "user": 29,
+    "badge": 6,
+    "moathon": null,
+    "obtained_at": "2025-12-24T02:38:34.973Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 66,
+  "fields": {
+    "user": 30,
+    "badge": 6,
+    "moathon": null,
+    "obtained_at": "2025-12-24T02:38:34.981Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 67,
+  "fields": {
+    "user": 30,
+    "badge": 9,
+    "moathon": null,
+    "obtained_at": "2025-12-24T02:38:34.985Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 68,
+  "fields": {
+    "user": 1,
+    "badge": 7,
+    "moathon": null,
+    "obtained_at": "2025-12-24T02:38:34.988Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 69,
+  "fields": {
+    "user": 1,
+    "badge": 12,
+    "moathon": null,
+    "obtained_at": "2025-12-24T02:38:34.993Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 70,
+  "fields": {
+    "user": 1,
+    "badge": 13,
+    "moathon": null,
+    "obtained_at": "2025-12-24T02:38:34.995Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 71,
+  "fields": {
+    "user": 2,
+    "badge": 1,
+    "moathon": 3,
+    "obtained_at": "2025-12-24T02:38:34.998Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 72,
+  "fields": {
+    "user": 2,
+    "badge": 2,
+    "moathon": 3,
+    "obtained_at": "2025-12-24T02:38:34.999Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 73,
+  "fields": {
+    "user": 2,
+    "badge": 3,
+    "moathon": 3,
+    "obtained_at": "2025-12-24T02:38:35.000Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 74,
+  "fields": {
+    "user": 2,
+    "badge": 7,
+    "moathon": null,
+    "obtained_at": "2025-12-24T02:38:35.002Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 75,
+  "fields": {
+    "user": 2,
+    "badge": 10,
+    "moathon": null,
+    "obtained_at": "2025-12-24T02:38:35.007Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 76,
+  "fields": {
+    "user": 3,
+    "badge": 1,
+    "moathon": 6,
+    "obtained_at": "2025-12-24T02:38:35.012Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 77,
+  "fields": {
+    "user": 3,
+    "badge": 1,
+    "moathon": 7,
+    "obtained_at": "2025-12-24T02:38:35.014Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 78,
+  "fields": {
+    "user": 3,
+    "badge": 2,
+    "moathon": 7,
+    "obtained_at": "2025-12-24T02:38:35.016Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 79,
+  "fields": {
+    "user": 3,
+    "badge": 1,
+    "moathon": 9,
+    "obtained_at": "2025-12-24T02:38:35.017Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 80,
+  "fields": {
+    "user": 3,
+    "badge": 7,
+    "moathon": null,
+    "obtained_at": "2025-12-24T02:38:35.019Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 81,
+  "fields": {
+    "user": 3,
+    "badge": 10,
+    "moathon": null,
+    "obtained_at": "2025-12-24T02:38:35.026Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 82,
+  "fields": {
+    "user": 4,
+    "badge": 1,
+    "moathon": 10,
+    "obtained_at": "2025-12-24T02:38:35.029Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 83,
+  "fields": {
+    "user": 4,
+    "badge": 2,
+    "moathon": 10,
+    "obtained_at": "2025-12-24T02:38:35.031Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 84,
+  "fields": {
+    "user": 4,
+    "badge": 3,
+    "moathon": 10,
+    "obtained_at": "2025-12-24T02:38:35.032Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 85,
+  "fields": {
+    "user": 4,
+    "badge": 1,
+    "moathon": 11,
+    "obtained_at": "2025-12-24T02:38:35.034Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 86,
+  "fields": {
+    "user": 4,
+    "badge": 7,
+    "moathon": null,
+    "obtained_at": "2025-12-24T02:38:35.036Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 87,
+  "fields": {
+    "user": 4,
+    "badge": 12,
+    "moathon": null,
+    "obtained_at": "2025-12-24T02:38:35.040Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 88,
+  "fields": {
+    "user": 4,
+    "badge": 13,
+    "moathon": null,
+    "obtained_at": "2025-12-24T02:38:35.042Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 89,
+  "fields": {
+    "user": 5,
+    "badge": 1,
+    "moathon": 13,
+    "obtained_at": "2025-12-24T02:38:35.044Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 90,
+  "fields": {
+    "user": 5,
+    "badge": 2,
+    "moathon": 13,
+    "obtained_at": "2025-12-24T02:38:35.045Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 91,
+  "fields": {
+    "user": 5,
+    "badge": 3,
+    "moathon": 13,
+    "obtained_at": "2025-12-24T02:38:35.047Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 92,
+  "fields": {
+    "user": 5,
+    "badge": 1,
+    "moathon": 14,
+    "obtained_at": "2025-12-24T02:38:35.048Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 93,
+  "fields": {
+    "user": 5,
+    "badge": 2,
+    "moathon": 14,
+    "obtained_at": "2025-12-24T02:38:35.050Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 94,
+  "fields": {
+    "user": 5,
+    "badge": 7,
+    "moathon": null,
+    "obtained_at": "2025-12-24T02:38:35.051Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 95,
+  "fields": {
+    "user": 5,
+    "badge": 11,
+    "moathon": null,
+    "obtained_at": "2025-12-24T02:38:35.056Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 96,
+  "fields": {
+    "user": 5,
+    "badge": 10,
+    "moathon": null,
+    "obtained_at": "2025-12-24T02:38:35.058Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 97,
+  "fields": {
+    "user": 6,
+    "badge": 1,
+    "moathon": 15,
+    "obtained_at": "2025-12-24T02:38:35.061Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 98,
+  "fields": {
+    "user": 6,
+    "badge": 2,
+    "moathon": 15,
+    "obtained_at": "2025-12-24T02:38:35.062Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 99,
+  "fields": {
+    "user": 6,
+    "badge": 3,
+    "moathon": 15,
+    "obtained_at": "2025-12-24T02:38:35.063Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 100,
+  "fields": {
+    "user": 6,
+    "badge": 4,
+    "moathon": 15,
+    "obtained_at": "2025-12-24T02:38:35.065Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 101,
+  "fields": {
+    "user": 6,
+    "badge": 1,
+    "moathon": 16,
+    "obtained_at": "2025-12-24T02:38:35.066Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 102,
+  "fields": {
+    "user": 6,
+    "badge": 2,
+    "moathon": 16,
+    "obtained_at": "2025-12-24T02:38:35.068Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 103,
+  "fields": {
+    "user": 6,
+    "badge": 7,
+    "moathon": null,
+    "obtained_at": "2025-12-24T02:38:35.070Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 104,
+  "fields": {
+    "user": 6,
+    "badge": 11,
+    "moathon": null,
+    "obtained_at": "2025-12-24T02:38:35.074Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 105,
+  "fields": {
+    "user": 7,
+    "badge": 1,
+    "moathon": 18,
+    "obtained_at": "2025-12-24T02:38:35.077Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 106,
+  "fields": {
+    "user": 7,
+    "badge": 1,
+    "moathon": 20,
+    "obtained_at": "2025-12-24T02:38:35.079Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 107,
+  "fields": {
+    "user": 7,
+    "badge": 1,
+    "moathon": 21,
+    "obtained_at": "2025-12-24T02:38:35.080Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 108,
+  "fields": {
+    "user": 7,
+    "badge": 7,
+    "moathon": null,
+    "obtained_at": "2025-12-24T02:38:35.082Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 109,
+  "fields": {
+    "user": 7,
+    "badge": 11,
+    "moathon": null,
+    "obtained_at": "2025-12-24T02:38:35.087Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 110,
+  "fields": {
+    "user": 8,
+    "badge": 7,
+    "moathon": null,
+    "obtained_at": "2025-12-24T02:38:35.090Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 111,
+  "fields": {
+    "user": 9,
+    "badge": 1,
+    "moathon": 25,
+    "obtained_at": "2025-12-24T02:38:35.096Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 112,
+  "fields": {
+    "user": 9,
+    "badge": 1,
+    "moathon": 26,
+    "obtained_at": "2025-12-24T02:38:35.097Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 113,
+  "fields": {
+    "user": 9,
+    "badge": 1,
+    "moathon": 28,
+    "obtained_at": "2025-12-24T02:38:35.099Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 114,
+  "fields": {
+    "user": 9,
+    "badge": 7,
+    "moathon": null,
+    "obtained_at": "2025-12-24T02:38:35.101Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 115,
+  "fields": {
+    "user": 9,
+    "badge": 10,
+    "moathon": null,
+    "obtained_at": "2025-12-24T02:38:35.107Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 116,
+  "fields": {
+    "user": 10,
+    "badge": 1,
+    "moathon": 29,
+    "obtained_at": "2025-12-24T02:38:35.109Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 117,
+  "fields": {
+    "user": 10,
+    "badge": 2,
+    "moathon": 29,
+    "obtained_at": "2025-12-24T02:38:35.111Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 118,
+  "fields": {
+    "user": 10,
+    "badge": 3,
+    "moathon": 29,
+    "obtained_at": "2025-12-24T02:38:35.112Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 119,
+  "fields": {
+    "user": 10,
+    "badge": 4,
+    "moathon": 29,
+    "obtained_at": "2025-12-24T02:38:35.114Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 120,
+  "fields": {
+    "user": 10,
+    "badge": 1,
+    "moathon": 30,
+    "obtained_at": "2025-12-24T02:38:35.115Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 121,
+  "fields": {
+    "user": 10,
+    "badge": 1,
+    "moathon": 31,
+    "obtained_at": "2025-12-24T02:38:35.117Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 122,
+  "fields": {
+    "user": 10,
+    "badge": 1,
+    "moathon": 32,
+    "obtained_at": "2025-12-24T02:38:35.118Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 123,
+  "fields": {
+    "user": 10,
+    "badge": 2,
+    "moathon": 32,
+    "obtained_at": "2025-12-24T02:38:35.119Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 124,
+  "fields": {
+    "user": 10,
+    "badge": 7,
+    "moathon": null,
+    "obtained_at": "2025-12-24T02:38:35.121Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 125,
+  "fields": {
+    "user": 10,
+    "badge": 11,
+    "moathon": null,
+    "obtained_at": "2025-12-24T02:38:35.126Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 126,
+  "fields": {
+    "user": 11,
+    "badge": 1,
+    "moathon": 33,
+    "obtained_at": "2025-12-24T02:38:35.130Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 127,
+  "fields": {
+    "user": 11,
+    "badge": 1,
+    "moathon": 34,
+    "obtained_at": "2025-12-24T02:38:35.132Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 128,
+  "fields": {
+    "user": 11,
+    "badge": 2,
+    "moathon": 34,
+    "obtained_at": "2025-12-24T02:38:35.133Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 129,
+  "fields": {
+    "user": 11,
+    "badge": 7,
+    "moathon": null,
+    "obtained_at": "2025-12-24T02:38:35.135Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 130,
+  "fields": {
+    "user": 11,
+    "badge": 11,
+    "moathon": null,
+    "obtained_at": "2025-12-24T02:38:35.138Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 131,
+  "fields": {
+    "user": 12,
+    "badge": 1,
+    "moathon": 35,
+    "obtained_at": "2025-12-24T02:38:35.142Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 132,
+  "fields": {
+    "user": 12,
+    "badge": 1,
+    "moathon": 36,
+    "obtained_at": "2025-12-24T02:38:35.143Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 133,
+  "fields": {
+    "user": 12,
+    "badge": 2,
+    "moathon": 36,
+    "obtained_at": "2025-12-24T02:38:35.145Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 134,
+  "fields": {
+    "user": 12,
+    "badge": 3,
+    "moathon": 36,
+    "obtained_at": "2025-12-24T02:38:35.146Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 135,
+  "fields": {
+    "user": 12,
+    "badge": 7,
+    "moathon": null,
+    "obtained_at": "2025-12-24T02:38:35.148Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 136,
+  "fields": {
+    "user": 13,
+    "badge": 1,
+    "moathon": 37,
+    "obtained_at": "2025-12-24T02:38:35.153Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 137,
+  "fields": {
+    "user": 13,
+    "badge": 2,
+    "moathon": 37,
+    "obtained_at": "2025-12-24T02:38:35.155Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 138,
+  "fields": {
+    "user": 13,
+    "badge": 1,
+    "moathon": 38,
+    "obtained_at": "2025-12-24T02:38:35.156Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 139,
+  "fields": {
+    "user": 13,
+    "badge": 7,
+    "moathon": null,
+    "obtained_at": "2025-12-24T02:38:35.158Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 140,
+  "fields": {
+    "user": 14,
+    "badge": 1,
+    "moathon": 40,
+    "obtained_at": "2025-12-24T02:38:35.164Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 141,
+  "fields": {
+    "user": 14,
+    "badge": 1,
+    "moathon": 41,
+    "obtained_at": "2025-12-24T02:38:35.165Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 142,
+  "fields": {
+    "user": 14,
+    "badge": 7,
+    "moathon": null,
+    "obtained_at": "2025-12-24T02:38:35.167Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 143,
+  "fields": {
+    "user": 15,
+    "badge": 1,
+    "moathon": 44,
+    "obtained_at": "2025-12-24T02:38:35.173Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 144,
+  "fields": {
+    "user": 15,
+    "badge": 1,
+    "moathon": 45,
+    "obtained_at": "2025-12-24T02:38:35.175Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 145,
+  "fields": {
+    "user": 15,
+    "badge": 7,
+    "moathon": null,
+    "obtained_at": "2025-12-24T02:38:35.177Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 146,
+  "fields": {
+    "user": 16,
+    "badge": 1,
+    "moathon": 46,
+    "obtained_at": "2025-12-24T02:38:35.183Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 147,
+  "fields": {
+    "user": 16,
+    "badge": 2,
+    "moathon": 46,
+    "obtained_at": "2025-12-24T02:38:35.184Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 148,
+  "fields": {
+    "user": 16,
+    "badge": 1,
+    "moathon": 47,
+    "obtained_at": "2025-12-24T02:38:35.186Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 149,
+  "fields": {
+    "user": 16,
+    "badge": 2,
+    "moathon": 47,
+    "obtained_at": "2025-12-24T02:38:35.187Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 150,
+  "fields": {
+    "user": 16,
+    "badge": 3,
+    "moathon": 47,
+    "obtained_at": "2025-12-24T02:38:35.189Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 151,
+  "fields": {
+    "user": 16,
+    "badge": 4,
+    "moathon": 47,
+    "obtained_at": "2025-12-24T02:38:35.190Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 152,
+  "fields": {
+    "user": 16,
+    "badge": 7,
+    "moathon": null,
+    "obtained_at": "2025-12-24T02:38:35.192Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 153,
+  "fields": {
+    "user": 16,
+    "badge": 10,
+    "moathon": null,
+    "obtained_at": "2025-12-24T02:38:35.197Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 154,
+  "fields": {
+    "user": 17,
+    "badge": 1,
+    "moathon": 49,
+    "obtained_at": "2025-12-24T02:38:35.200Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 155,
+  "fields": {
+    "user": 17,
+    "badge": 2,
+    "moathon": 49,
+    "obtained_at": "2025-12-24T02:38:35.202Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 156,
+  "fields": {
+    "user": 17,
+    "badge": 3,
+    "moathon": 49,
+    "obtained_at": "2025-12-24T02:38:35.203Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 157,
+  "fields": {
+    "user": 17,
+    "badge": 4,
+    "moathon": 49,
+    "obtained_at": "2025-12-24T02:38:35.204Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 158,
+  "fields": {
+    "user": 17,
+    "badge": 1,
+    "moathon": 51,
+    "obtained_at": "2025-12-24T02:38:35.206Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 159,
+  "fields": {
+    "user": 17,
+    "badge": 7,
+    "moathon": null,
+    "obtained_at": "2025-12-24T02:38:35.208Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 160,
+  "fields": {
+    "user": 18,
+    "badge": 1,
+    "moathon": 52,
+    "obtained_at": "2025-12-24T02:38:35.213Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 161,
+  "fields": {
+    "user": 18,
+    "badge": 2,
+    "moathon": 52,
+    "obtained_at": "2025-12-24T02:38:35.215Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 162,
+  "fields": {
+    "user": 18,
+    "badge": 3,
+    "moathon": 52,
+    "obtained_at": "2025-12-24T02:38:35.216Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 163,
+  "fields": {
+    "user": 18,
+    "badge": 4,
+    "moathon": 52,
+    "obtained_at": "2025-12-24T02:38:35.218Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 164,
+  "fields": {
+    "user": 18,
+    "badge": 1,
+    "moathon": 53,
+    "obtained_at": "2025-12-24T02:38:35.219Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 165,
+  "fields": {
+    "user": 18,
+    "badge": 2,
+    "moathon": 53,
+    "obtained_at": "2025-12-24T02:38:35.220Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 166,
+  "fields": {
+    "user": 18,
+    "badge": 1,
+    "moathon": 54,
+    "obtained_at": "2025-12-24T02:38:35.222Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 167,
+  "fields": {
+    "user": 18,
+    "badge": 2,
+    "moathon": 54,
+    "obtained_at": "2025-12-24T02:38:35.223Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 168,
+  "fields": {
+    "user": 18,
+    "badge": 3,
+    "moathon": 54,
+    "obtained_at": "2025-12-24T02:38:35.225Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 169,
+  "fields": {
+    "user": 18,
+    "badge": 1,
+    "moathon": 55,
+    "obtained_at": "2025-12-24T02:38:35.226Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 170,
+  "fields": {
+    "user": 18,
+    "badge": 2,
+    "moathon": 55,
+    "obtained_at": "2025-12-24T02:38:35.227Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 171,
+  "fields": {
+    "user": 18,
+    "badge": 3,
+    "moathon": 55,
+    "obtained_at": "2025-12-24T02:38:35.229Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 172,
+  "fields": {
+    "user": 18,
+    "badge": 4,
+    "moathon": 55,
+    "obtained_at": "2025-12-24T02:38:35.230Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 173,
+  "fields": {
+    "user": 18,
+    "badge": 7,
+    "moathon": null,
+    "obtained_at": "2025-12-24T02:38:35.232Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 174,
+  "fields": {
+    "user": 19,
+    "badge": 1,
+    "moathon": 57,
+    "obtained_at": "2025-12-24T02:38:35.240Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 175,
+  "fields": {
+    "user": 19,
+    "badge": 1,
+    "moathon": 58,
+    "obtained_at": "2025-12-24T02:38:35.242Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 176,
+  "fields": {
+    "user": 19,
+    "badge": 1,
+    "moathon": 59,
+    "obtained_at": "2025-12-24T02:38:35.243Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 177,
+  "fields": {
+    "user": 19,
+    "badge": 1,
+    "moathon": 60,
+    "obtained_at": "2025-12-24T02:38:35.244Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 178,
+  "fields": {
+    "user": 19,
+    "badge": 1,
+    "moathon": 61,
+    "obtained_at": "2025-12-24T02:38:35.246Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 179,
+  "fields": {
+    "user": 19,
+    "badge": 7,
+    "moathon": null,
+    "obtained_at": "2025-12-24T02:38:35.247Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 180,
+  "fields": {
+    "user": 20,
+    "badge": 1,
+    "moathon": 62,
+    "obtained_at": "2025-12-24T02:38:35.255Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 181,
+  "fields": {
+    "user": 20,
+    "badge": 2,
+    "moathon": 62,
+    "obtained_at": "2025-12-24T02:38:35.257Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 182,
+  "fields": {
+    "user": 20,
+    "badge": 3,
+    "moathon": 62,
+    "obtained_at": "2025-12-24T02:38:35.258Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 183,
+  "fields": {
+    "user": 20,
+    "badge": 1,
+    "moathon": 64,
+    "obtained_at": "2025-12-24T02:38:35.260Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 184,
+  "fields": {
+    "user": 20,
+    "badge": 2,
+    "moathon": 64,
+    "obtained_at": "2025-12-24T02:38:35.261Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 185,
+  "fields": {
+    "user": 20,
+    "badge": 3,
+    "moathon": 64,
+    "obtained_at": "2025-12-24T02:38:35.262Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 186,
+  "fields": {
+    "user": 20,
+    "badge": 4,
+    "moathon": 64,
+    "obtained_at": "2025-12-24T02:38:35.264Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 187,
+  "fields": {
+    "user": 20,
+    "badge": 7,
+    "moathon": null,
+    "obtained_at": "2025-12-24T02:38:35.266Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 188,
+  "fields": {
+    "user": 20,
+    "badge": 11,
+    "moathon": null,
+    "obtained_at": "2025-12-24T02:38:35.270Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 189,
+  "fields": {
+    "user": 21,
+    "badge": 1,
+    "moathon": 67,
+    "obtained_at": "2025-12-24T02:38:35.273Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 190,
+  "fields": {
+    "user": 21,
+    "badge": 2,
+    "moathon": 67,
+    "obtained_at": "2025-12-24T02:38:35.275Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 191,
+  "fields": {
+    "user": 21,
+    "badge": 3,
+    "moathon": 67,
+    "obtained_at": "2025-12-24T02:38:35.276Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 192,
+  "fields": {
+    "user": 21,
+    "badge": 7,
+    "moathon": null,
+    "obtained_at": "2025-12-24T02:38:35.278Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 193,
+  "fields": {
+    "user": 21,
+    "badge": 12,
+    "moathon": null,
+    "obtained_at": "2025-12-24T02:38:35.283Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 194,
+  "fields": {
+    "user": 21,
+    "badge": 13,
+    "moathon": null,
+    "obtained_at": "2025-12-24T02:38:35.285Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 195,
+  "fields": {
+    "user": 22,
+    "badge": 1,
+    "moathon": 69,
+    "obtained_at": "2025-12-24T02:38:35.287Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 196,
+  "fields": {
+    "user": 22,
+    "badge": 2,
+    "moathon": 69,
+    "obtained_at": "2025-12-24T02:38:35.288Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 197,
+  "fields": {
+    "user": 22,
+    "badge": 3,
+    "moathon": 69,
+    "obtained_at": "2025-12-24T02:38:35.289Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 198,
+  "fields": {
+    "user": 22,
+    "badge": 1,
+    "moathon": 70,
+    "obtained_at": "2025-12-24T02:38:35.291Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 199,
+  "fields": {
+    "user": 22,
+    "badge": 2,
+    "moathon": 70,
+    "obtained_at": "2025-12-24T02:38:35.292Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 200,
+  "fields": {
+    "user": 22,
+    "badge": 3,
+    "moathon": 70,
+    "obtained_at": "2025-12-24T02:38:35.294Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 201,
+  "fields": {
+    "user": 22,
+    "badge": 7,
+    "moathon": null,
+    "obtained_at": "2025-12-24T02:38:35.295Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 202,
+  "fields": {
+    "user": 22,
+    "badge": 10,
+    "moathon": null,
+    "obtained_at": "2025-12-24T02:38:35.300Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 203,
+  "fields": {
+    "user": 23,
+    "badge": 1,
+    "moathon": 71,
+    "obtained_at": "2025-12-24T02:38:35.303Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 204,
+  "fields": {
+    "user": 23,
+    "badge": 1,
+    "moathon": 72,
+    "obtained_at": "2025-12-24T02:38:35.304Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 205,
+  "fields": {
+    "user": 23,
+    "badge": 1,
+    "moathon": 73,
+    "obtained_at": "2025-12-24T02:38:35.306Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 206,
+  "fields": {
+    "user": 23,
+    "badge": 2,
+    "moathon": 73,
+    "obtained_at": "2025-12-24T02:38:35.307Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 207,
+  "fields": {
+    "user": 23,
+    "badge": 3,
+    "moathon": 73,
+    "obtained_at": "2025-12-24T02:38:35.308Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 208,
+  "fields": {
+    "user": 23,
+    "badge": 7,
+    "moathon": null,
+    "obtained_at": "2025-12-24T02:38:35.311Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 209,
+  "fields": {
+    "user": 24,
+    "badge": 1,
+    "moathon": 76,
+    "obtained_at": "2025-12-24T02:38:35.318Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 210,
+  "fields": {
+    "user": 24,
+    "badge": 1,
+    "moathon": 77,
+    "obtained_at": "2025-12-24T02:38:35.319Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 211,
+  "fields": {
+    "user": 24,
+    "badge": 2,
+    "moathon": 77,
+    "obtained_at": "2025-12-24T02:38:35.320Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 212,
+  "fields": {
+    "user": 24,
+    "badge": 7,
+    "moathon": null,
+    "obtained_at": "2025-12-24T02:38:35.322Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 213,
+  "fields": {
+    "user": 25,
+    "badge": 1,
+    "moathon": 78,
+    "obtained_at": "2025-12-24T02:38:35.328Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 214,
+  "fields": {
+    "user": 25,
+    "badge": 2,
+    "moathon": 78,
+    "obtained_at": "2025-12-24T02:38:35.330Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 215,
+  "fields": {
+    "user": 25,
+    "badge": 3,
+    "moathon": 78,
+    "obtained_at": "2025-12-24T02:38:35.331Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 216,
+  "fields": {
+    "user": 25,
+    "badge": 1,
+    "moathon": 80,
+    "obtained_at": "2025-12-24T02:38:35.333Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 217,
+  "fields": {
+    "user": 25,
+    "badge": 2,
+    "moathon": 80,
+    "obtained_at": "2025-12-24T02:38:35.334Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 218,
+  "fields": {
+    "user": 25,
+    "badge": 3,
+    "moathon": 80,
+    "obtained_at": "2025-12-24T02:38:35.335Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 219,
+  "fields": {
+    "user": 25,
+    "badge": 1,
+    "moathon": 81,
+    "obtained_at": "2025-12-24T02:38:35.337Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 220,
+  "fields": {
+    "user": 25,
+    "badge": 2,
+    "moathon": 81,
+    "obtained_at": "2025-12-24T02:38:35.338Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 221,
+  "fields": {
+    "user": 25,
+    "badge": 7,
+    "moathon": null,
+    "obtained_at": "2025-12-24T02:38:35.340Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 222,
+  "fields": {
+    "user": 26,
+    "badge": 1,
+    "moathon": 84,
+    "obtained_at": "2025-12-24T02:38:35.347Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 223,
+  "fields": {
+    "user": 26,
+    "badge": 1,
+    "moathon": 85,
+    "obtained_at": "2025-12-24T02:38:35.348Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 224,
+  "fields": {
+    "user": 26,
+    "badge": 7,
+    "moathon": null,
+    "obtained_at": "2025-12-24T02:38:35.350Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 225,
+  "fields": {
+    "user": 27,
+    "badge": 1,
+    "moathon": 86,
+    "obtained_at": "2025-12-24T02:38:35.357Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 226,
+  "fields": {
+    "user": 27,
+    "badge": 2,
+    "moathon": 86,
+    "obtained_at": "2025-12-24T02:38:35.359Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 227,
+  "fields": {
+    "user": 27,
+    "badge": 3,
+    "moathon": 86,
+    "obtained_at": "2025-12-24T02:38:35.360Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 228,
+  "fields": {
+    "user": 27,
+    "badge": 1,
+    "moathon": 87,
+    "obtained_at": "2025-12-24T02:38:35.361Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 229,
+  "fields": {
+    "user": 27,
+    "badge": 1,
+    "moathon": 88,
+    "obtained_at": "2025-12-24T02:38:35.363Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 230,
+  "fields": {
+    "user": 27,
+    "badge": 2,
+    "moathon": 88,
+    "obtained_at": "2025-12-24T02:38:35.364Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 231,
+  "fields": {
+    "user": 27,
+    "badge": 3,
+    "moathon": 88,
+    "obtained_at": "2025-12-24T02:38:35.366Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 232,
+  "fields": {
+    "user": 27,
+    "badge": 4,
+    "moathon": 88,
+    "obtained_at": "2025-12-24T02:38:35.367Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 233,
+  "fields": {
+    "user": 27,
+    "badge": 1,
+    "moathon": 89,
+    "obtained_at": "2025-12-24T02:38:35.368Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 234,
+  "fields": {
+    "user": 27,
+    "badge": 2,
+    "moathon": 89,
+    "obtained_at": "2025-12-24T02:38:35.370Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 235,
+  "fields": {
+    "user": 27,
+    "badge": 3,
+    "moathon": 89,
+    "obtained_at": "2025-12-24T02:38:35.371Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 236,
+  "fields": {
+    "user": 27,
+    "badge": 1,
+    "moathon": 90,
+    "obtained_at": "2025-12-24T02:38:35.373Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 237,
+  "fields": {
+    "user": 27,
+    "badge": 7,
+    "moathon": null,
+    "obtained_at": "2025-12-24T02:38:35.374Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 238,
+  "fields": {
+    "user": 27,
+    "badge": 11,
+    "moathon": null,
+    "obtained_at": "2025-12-24T02:38:35.380Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 239,
+  "fields": {
+    "user": 28,
+    "badge": 1,
+    "moathon": 91,
+    "obtained_at": "2025-12-24T02:38:35.384Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 240,
+  "fields": {
+    "user": 28,
+    "badge": 2,
+    "moathon": 91,
+    "obtained_at": "2025-12-24T02:38:35.385Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 241,
+  "fields": {
+    "user": 28,
+    "badge": 3,
+    "moathon": 91,
+    "obtained_at": "2025-12-24T02:38:35.387Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 242,
+  "fields": {
+    "user": 28,
+    "badge": 1,
+    "moathon": 92,
+    "obtained_at": "2025-12-24T02:38:35.388Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 243,
+  "fields": {
+    "user": 28,
+    "badge": 2,
+    "moathon": 92,
+    "obtained_at": "2025-12-24T02:38:35.390Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 244,
+  "fields": {
+    "user": 28,
+    "badge": 1,
+    "moathon": 93,
+    "obtained_at": "2025-12-24T02:38:35.391Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 245,
+  "fields": {
+    "user": 28,
+    "badge": 2,
+    "moathon": 93,
+    "obtained_at": "2025-12-24T02:38:35.392Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 246,
+  "fields": {
+    "user": 28,
+    "badge": 3,
+    "moathon": 93,
+    "obtained_at": "2025-12-24T02:38:35.394Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 247,
+  "fields": {
+    "user": 28,
+    "badge": 7,
+    "moathon": null,
+    "obtained_at": "2025-12-24T02:38:35.395Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 248,
+  "fields": {
+    "user": 28,
+    "badge": 11,
+    "moathon": null,
+    "obtained_at": "2025-12-24T02:38:35.400Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 249,
+  "fields": {
+    "user": 29,
+    "badge": 1,
+    "moathon": 94,
+    "obtained_at": "2025-12-24T02:38:35.403Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 250,
+  "fields": {
+    "user": 29,
+    "badge": 2,
+    "moathon": 94,
+    "obtained_at": "2025-12-24T02:38:35.405Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 251,
+  "fields": {
+    "user": 29,
+    "badge": 3,
+    "moathon": 94,
+    "obtained_at": "2025-12-24T02:38:35.406Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 252,
+  "fields": {
+    "user": 29,
+    "badge": 4,
+    "moathon": 94,
+    "obtained_at": "2025-12-24T02:38:35.407Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 253,
+  "fields": {
+    "user": 29,
+    "badge": 1,
+    "moathon": 95,
+    "obtained_at": "2025-12-24T02:38:35.409Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 254,
+  "fields": {
+    "user": 29,
+    "badge": 1,
+    "moathon": 96,
+    "obtained_at": "2025-12-24T02:38:35.410Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 255,
+  "fields": {
+    "user": 29,
+    "badge": 1,
+    "moathon": 97,
+    "obtained_at": "2025-12-24T02:38:35.411Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 256,
+  "fields": {
+    "user": 29,
+    "badge": 2,
+    "moathon": 97,
+    "obtained_at": "2025-12-24T02:38:35.412Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 257,
+  "fields": {
+    "user": 29,
+    "badge": 3,
+    "moathon": 97,
+    "obtained_at": "2025-12-24T02:38:35.414Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 258,
+  "fields": {
+    "user": 29,
+    "badge": 4,
+    "moathon": 97,
+    "obtained_at": "2025-12-24T02:38:35.415Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 259,
+  "fields": {
+    "user": 29,
+    "badge": 1,
+    "moathon": 98,
+    "obtained_at": "2025-12-24T02:38:35.417Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 260,
+  "fields": {
+    "user": 29,
+    "badge": 7,
+    "moathon": null,
+    "obtained_at": "2025-12-24T02:38:35.418Z"
+  }
+},
+{
+  "model": "accounts.userbadge",
+  "pk": 261,
+  "fields": {
+    "user": 30,
+    "badge": 7,
+    "moathon": null,
+    "obtained_at": "2025-12-24T02:38:35.427Z"
+  }
+},
+{
+  "model": "accounts.userfollow",
+  "pk": 1,
+  "fields": {
+    "follower": 10,
+    "following": 21,
+    "created_at": "2025-12-24T02:38:34.604Z"
+  }
+},
+{
+  "model": "accounts.userfollow",
+  "pk": 2,
+  "fields": {
+    "follower": 4,
+    "following": 21,
+    "created_at": "2025-12-24T02:38:34.607Z"
+  }
+},
+{
+  "model": "accounts.userfollow",
+  "pk": 3,
+  "fields": {
+    "follower": 11,
+    "following": 21,
+    "created_at": "2025-12-24T02:38:34.608Z"
+  }
+},
+{
+  "model": "accounts.userfollow",
+  "pk": 4,
+  "fields": {
+    "follower": 29,
+    "following": 21,
+    "created_at": "2025-12-24T02:38:34.609Z"
+  }
+},
+{
+  "model": "accounts.userfollow",
+  "pk": 5,
+  "fields": {
+    "follower": 16,
+    "following": 21,
+    "created_at": "2025-12-24T02:38:34.610Z"
+  }
+},
+{
+  "model": "accounts.userfollow",
+  "pk": 6,
+  "fields": {
+    "follower": 19,
+    "following": 21,
+    "created_at": "2025-12-24T02:38:34.611Z"
+  }
+},
+{
+  "model": "accounts.userfollow",
+  "pk": 7,
+  "fields": {
+    "follower": 2,
+    "following": 21,
+    "created_at": "2025-12-24T02:38:34.612Z"
+  }
+},
+{
+  "model": "accounts.userfollow",
+  "pk": 8,
+  "fields": {
+    "follower": 28,
+    "following": 21,
+    "created_at": "2025-12-24T02:38:34.613Z"
+  }
+},
+{
+  "model": "accounts.userfollow",
+  "pk": 9,
+  "fields": {
+    "follower": 5,
+    "following": 21,
+    "created_at": "2025-12-24T02:38:34.614Z"
+  }
+},
+{
+  "model": "accounts.userfollow",
+  "pk": 10,
+  "fields": {
+    "follower": 6,
+    "following": 21,
+    "created_at": "2025-12-24T02:38:34.614Z"
+  }
+},
+{
+  "model": "accounts.userfollow",
+  "pk": 11,
+  "fields": {
+    "follower": 26,
+    "following": 4,
+    "created_at": "2025-12-24T02:38:34.615Z"
+  }
+},
+{
+  "model": "accounts.userfollow",
+  "pk": 12,
+  "fields": {
+    "follower": 20,
+    "following": 4,
+    "created_at": "2025-12-24T02:38:34.616Z"
+  }
+},
+{
+  "model": "accounts.userfollow",
+  "pk": 13,
+  "fields": {
+    "follower": 7,
+    "following": 4,
+    "created_at": "2025-12-24T02:38:34.617Z"
+  }
+},
+{
+  "model": "accounts.userfollow",
+  "pk": 14,
+  "fields": {
+    "follower": 24,
+    "following": 4,
+    "created_at": "2025-12-24T02:38:34.618Z"
+  }
+},
+{
+  "model": "accounts.userfollow",
+  "pk": 15,
+  "fields": {
+    "follower": 12,
+    "following": 4,
+    "created_at": "2025-12-24T02:38:34.619Z"
+  }
+},
+{
+  "model": "accounts.userfollow",
+  "pk": 16,
+  "fields": {
+    "follower": 9,
+    "following": 4,
+    "created_at": "2025-12-24T02:38:34.620Z"
+  }
+},
+{
+  "model": "accounts.userfollow",
+  "pk": 17,
+  "fields": {
+    "follower": 8,
+    "following": 4,
+    "created_at": "2025-12-24T02:38:34.620Z"
+  }
+},
+{
+  "model": "accounts.userfollow",
+  "pk": 18,
+  "fields": {
+    "follower": 27,
+    "following": 4,
+    "created_at": "2025-12-24T02:38:34.621Z"
+  }
+},
+{
+  "model": "accounts.userfollow",
+  "pk": 19,
+  "fields": {
+    "follower": 6,
+    "following": 4,
+    "created_at": "2025-12-24T02:38:34.622Z"
+  }
+},
+{
+  "model": "accounts.userfollow",
+  "pk": 20,
+  "fields": {
+    "follower": 15,
+    "following": 4,
+    "created_at": "2025-12-24T02:38:34.623Z"
+  }
+},
+{
+  "model": "accounts.userfollow",
+  "pk": 21,
+  "fields": {
+    "follower": 14,
+    "following": 1,
+    "created_at": "2025-12-24T02:38:34.623Z"
+  }
+},
+{
+  "model": "accounts.userfollow",
+  "pk": 22,
+  "fields": {
+    "follower": 25,
+    "following": 1,
+    "created_at": "2025-12-24T02:38:34.624Z"
+  }
+},
+{
+  "model": "accounts.userfollow",
+  "pk": 23,
+  "fields": {
+    "follower": 15,
+    "following": 1,
+    "created_at": "2025-12-24T02:38:34.625Z"
+  }
+},
+{
+  "model": "accounts.userfollow",
+  "pk": 24,
+  "fields": {
+    "follower": 11,
+    "following": 1,
+    "created_at": "2025-12-24T02:38:34.626Z"
+  }
+},
+{
+  "model": "accounts.userfollow",
+  "pk": 25,
+  "fields": {
+    "follower": 21,
+    "following": 1,
+    "created_at": "2025-12-24T02:38:34.627Z"
+  }
+},
+{
+  "model": "accounts.userfollow",
+  "pk": 26,
+  "fields": {
+    "follower": 16,
+    "following": 1,
+    "created_at": "2025-12-24T02:38:34.627Z"
+  }
+},
+{
+  "model": "accounts.userfollow",
+  "pk": 27,
+  "fields": {
+    "follower": 3,
+    "following": 1,
+    "created_at": "2025-12-24T02:38:34.628Z"
+  }
+},
+{
+  "model": "accounts.userfollow",
+  "pk": 28,
+  "fields": {
+    "follower": 2,
+    "following": 1,
+    "created_at": "2025-12-24T02:38:34.629Z"
+  }
+},
+{
+  "model": "accounts.userfollow",
+  "pk": 29,
+  "fields": {
+    "follower": 17,
+    "following": 1,
+    "created_at": "2025-12-24T02:38:34.630Z"
+  }
+},
+{
+  "model": "accounts.userfollow",
+  "pk": 30,
+  "fields": {
+    "follower": 5,
+    "following": 1,
+    "created_at": "2025-12-24T02:38:34.631Z"
+  }
+}
+]

--- a/backend/accounts/management/commands/seed_fake_users_moathon.py
+++ b/backend/accounts/management/commands/seed_fake_users_moathon.py
@@ -11,7 +11,7 @@ from accounts.models import User
 from challenges.models import Moathon
 from products.models import ProductOption
 
-# 하한과 상한을 기반으로 데이터 품질, 현실성 반영 
+# 하한과 상한을 기반으로 데이터 품질, 현실성 반영
 def clamp_int(x: float, lo: int, hi: int) -> int:
     return int(max(lo, min(hi, round(x))))
 
@@ -19,14 +19,14 @@ def clamp_int(x: float, lo: int, hi: int) -> int:
 class Command(BaseCommand):
     help = "Seed fake Users and Moathon rows (real ProductOption ids only)."
 
-    # 명령어 실행시 옵션 
+    # 명령어 실행시 옵션
     def add_arguments(self, parser):
         parser.add_argument("--users", type=int, default=20000)
         parser.add_argument("--moathons", type=int, default=40000)
         parser.add_argument("--seed", type=int, default=42)
-        parser.add_argument("--password", type=str, default="fakePw!234")  # 로그인 안 할 거라서 동일비번으로 만듬 
+        parser.add_argument("--password", type=str, default="fakePw!234")  # 로그인 안 할 거라서 동일비번으로 만듬
 
-    # 실제 실행 로직 
+    # 실제 실행 로직
     def handle(self, *args, **opts):
         n_users = opts["users"]
         n_moathons = opts["moathons"]
@@ -44,8 +44,8 @@ class Command(BaseCommand):
         if not options:
             self.stdout.write(self.style.ERROR("ProductOption 데이터가 없습니다. 먼저 금융상품 데이터를 적재하세요."))
             return
-        
-        # 옵션을 비교할 때 최고 우대금리 존재하면 최고 우대금리 아니면 기본 금리 
+
+        # 옵션을 비교할 때 최고 우대금리 존재하면 최고 우대금리 아니면 기본 금리
         def option_rate(opt: ProductOption) -> float:
             v = opt.intr_rate2 if opt.intr_rate2 is not None else opt.intr_rate
             try:
@@ -101,9 +101,9 @@ class Command(BaseCommand):
                 pass
 
         # 특정 상품, 은행으로 가입이 몰리는 현상 반영 (숫자가 클수록 쏠림 커짐)
-        ALPHA_PROD = 1.25    # 상품 쏠림 
-        ALPHA_BANK = 1.05    # 은행 쏠림 
-        BANK_EFFECT = 0.25   # 은행 선호 영향 
+        ALPHA_PROD = 1.25    # 상품 쏠림
+        ALPHA_BANK = 1.05    # 은행 쏠림
+        BANK_EFFECT = 0.25   # 은행 선호 영향
 
         bank_ids = sorted(set(product_bank.values()))
         bank_weight = {bid: 1.0 / ((i + 1) ** ALPHA_BANK) for i, bid in enumerate(bank_ids, start=0)}
@@ -131,12 +131,19 @@ class Command(BaseCommand):
             for term in opts_by_product_term[pid].keys():
                 products_by_type_term[ptype][term].append(pid)
 
-        # 2) User 생성 
+        # 2) User 생성
         users = []
 
         # 닉네임 유니크 보장
-        def unique_nickname(i: int) -> str:
-            return f"seed{seed}_nick{random.randint(10_000_000, 99_999_999)}_{i}"
+        def unique_nickname(email: str) -> str:
+            local = (email or "").split("@", 1)[0].strip().lower()
+            base = local or "user"
+            nickname = base
+            suffix = 2
+            while User.objects.filter(nickname=nickname).exists():
+                nickname = f"{base}_{suffix}"
+                suffix += 1
+            return nickname
 
         # 나이 분포: 20~30대 위주 + 40~50대 일부
         def sample_birth_date():
@@ -152,7 +159,7 @@ class Command(BaseCommand):
         def sample_credit_score():
             return clamp_int(random.gauss(800, 70), 500, 950)
 
-        # 연봉(원): 평균 4,500만 근처 
+        # 연봉(원): 평균 4,500만 근처
         def sample_salary_won():
             return clamp_int(random.gauss(45_000_000, 18_000_000), 18_000_000, 150_000_000)
 
@@ -188,7 +195,7 @@ class Command(BaseCommand):
         )
 
         for i in range(n_users):
-            username = f"fake_{seed}_{i}"  
+            username = f"fake_{seed}_{i}"
             first = faker.first_name()
             last = faker.last_name()
             base_username = f"{last}{first}"   # 김순옥
@@ -223,7 +230,7 @@ class Command(BaseCommand):
                     is_superuser=False,
                     date_joined=joined,
 
-                    nickname=unique_nickname(i),
+                    nickname=unique_nickname(email),
                     birth=birth,
                     gender=random.choice(gender_choices),
                     credit_score=credit,
@@ -233,6 +240,7 @@ class Command(BaseCommand):
                     tender=tender,
                 )
             )
+        last_id = User.objects.order_by("-id").values_list("id", flat=True).first() or 0
 
         with transaction.atomic():
             User.objects.bulk_create(users, batch_size=2000)
@@ -240,8 +248,8 @@ class Command(BaseCommand):
         # 방금 만든 유저만 다시 로드(필요 필드만)
         user_rows = list(
             User.objects
-            .filter(nickname__startswith=f"seed{seed}_nick")
-            .values("id", "salary", "assets", "average_monthly_spend")
+            .filter(id__gt=last_id)
+            .values("id", "nickname", "salary", "assets", "average_monthly_spend")
         )
         self.stdout.write(self.style.SUCCESS(f"Users created: {len(user_rows)}"))
 
@@ -449,28 +457,69 @@ class Command(BaseCommand):
 
             return start, target
 
-        # 타이틀: 30% 커스텀, 70% user's moathon
+        # 타이틀: 80% 커스텀, 20% user's moathon
         custom_titles = {
-            "GOAL": ["결혼자금", "내집마련", "이사자금", "차량구입", "유학준비"],
-            "SHORT": ["비상금", "단기여유자금", "여행모아톤", "이벤트자금"],
-            "SAFE": ["안전자산", "현금보관", "예비자금", "원금보장"],
-            "HABIT": ["저축습관", "월급루틴", "자동저축", "한달저축"],
-            "YIELD": ["이자극대화", "우대금리도전", "금리챙기기"],
+            "GOAL": [
+                "결혼자금", "신혼여행자금", "예식비용", "혼수마련", "청첩장비용",
+                "내집마련", "청약통장플랜", "전세자금", "보증금모으기", "주택자금",
+                "이사자금", "이사비용", "인테리어자금", "가구·가전구입", "리모델링자금",
+                "차량구입", "첫차마련", "중고차자금", "자동차계약금", "면허·보험준비",
+                "유학준비", "어학연수", "학비모으기", "등록금플랜", "교환학생준비",
+                "창업자금", "사업시드", "장비구입비", "초기운영자금", "스몰비즈플랜",
+                "자격증비용", "시험준비비", "수강료모으기", "부트캠프등록금", "커리어업그레이드",
+                "부모님선물", "가족여행자금", "효도여행", "기념일선물", "집들이선물",
+                "출산준비", "육아용품", "산후조리원", "가정보험준비", "가족확장플랜",
+            ],
+            "SHORT": [
+                "비상금", "생활비버퍼", "급전대비", "돌발지출대비", "긴급예산",
+                "단기여유자금", "월말방어", "주말소비통제", "소확행예산", "이번달여유",
+                "여행모아톤", "항공권모으기", "숙소비용", "맛집투어자금", "휴가비용",
+                "이벤트자금", "생일선물비", "기념일데이트", "연말모임비", "경조사비",
+                "의료비예비", "치과비용", "검진비용", "약값모으기", "병원비버퍼",
+                "수리비용", "차량수리비", "핸드폰교체비", "가전수리비", "집수리예산",
+                "취미예산", "운동등록비", "레슨비용", "덕질예산", "공연·전시예산",
+                "이직준비", "면접정장비", "포트폴리오비", "취업준비비", "이직버퍼",
+            ],
+            "SAFE": [
+                "안전자산", "현금보관", "현금쿠션", "원금보장", "무위험보관",
+                "예비자금", "생활안정자금", "가계안전망", "리스크제로", "안정플랜",
+                "목돈보관", "대기자금", "잠깐보관", "현금파킹", "대기예치",
+                "비상금플랜", "긴급자금통장", "안전통장", "세이프박스", "마음안정통장",
+                "가족안전망", "부모님비상금", "아이교육예비", "가정안정자금", "가족쿠션",
+                "보험료대비", "연납보험료", "자동이체버퍼", "고정비방어", "지출안정화",
+                "환율변동대비", "해외결제대비", "여행비상금", "비상현금", "예비달러",
+            ],
+            "HABIT": [
+                "저축습관", "월급루틴", "자동저축", "한달저축", "매일저축",
+                "1일1저축", "주간저축", "월간저축", "루틴챌린지", "습관만들기",
+                "라떼값저축", "커피값모으기", "배달비절약", "소비줄이기", "지출다이어트",
+                "선저축후소비", "통장쪼개기", "용돈관리", "가계부루틴", "소비통제",
+                "적금루틴", "자동이체습관", "만기까지버티기", "완주챌린지", "꾸준함훈련",
+                "월급날저축", "주급저축", "잔돈모으기", "잔액저축", "남는돈저축",
+                "노플렉스챌린지", "무지출데이", "지출리셋", "소비리셋", "절약모드",
+            ],
+            "YIELD": [
+                "이자극대화", "우대금리도전", "금리챙기기", "이자수확", "금리사냥",
+                "고금리플랜", "금리상승기대", "최고금리찾기", "우대조건올클", "금리최적화",
+                "복리의마법", "이자재투자", "이자불리기", "수익률루틴", "수익챌린지",
+                "만기이자극대화", "우대금리모으기", "조건충족플랜", "월별우대달성", "혜택풀세팅",
+                "금리비교", "상품갈아타기", "리밸런싱", "금리런", "고금리환승",
+                "단리vs복리", "복리우선", "이자계산습관", "우대체크", "금리체크",
+                "파킹+적금", "파킹최적화", "예치전략", "분산예치", "금리분산",
+            ],
         }
 
-        def next_users_moathon_title(used_titles: set):
-            base = "user's moathon"
+        def next_users_moathon_title(nickname: str, used_titles: set):
+            nick = (nickname or "user").strip()
+            base = f"{nick}'s moathon"
+
             if base not in used_titles:
                 return base
-            max_n = 1
-            for t in used_titles:
-                if t == base:
-                    max_n = max(max_n, 1)
-                elif t.startswith(base):
-                    suf = t[len(base):]
-                    if suf.isdigit():
-                        max_n = max(max_n, int(suf))
-            return f"{base}{max_n + 1}"
+
+            n = 2
+            while f"{base}{n}" in used_titles:
+                n += 1
+            return f"{base}{n}"
 
         # 5) Moathon bulk 생성 (save() 미호출이므로 title, start_date, end_date 직접 생성)
         moathons = []
@@ -487,7 +536,7 @@ class Command(BaseCommand):
                 opt = pick_option(ptype, term, purpose, used_option_ids)
                 start_amt, target_amt = amounts_for(urow, opt, ptype, purpose, term)
 
-                if random.random() < 0.30:
+                if random.random() < 0.80:
                     base_title = random.choice(custom_titles[purpose])
                     title = base_title
                     n = 2
@@ -495,10 +544,10 @@ class Command(BaseCommand):
                         title = f"{base_title}{n}"
                         n += 1
                 else:
-                    title = next_users_moathon_title(used_titles)
+                    title = next_users_moathon_title(urow["nickname"], used_titles)
 
                 used_titles.add(title)
-                
+
                 days_ago = random.randint(0, 365) # 0일(오늘) ~ 365일 전 사이
                 rand_start_date = today - timedelta(days=days_ago)
                 calc_end_date = rand_start_date + timedelta(days=term * 30)

--- a/backend/accounts/services/badge_functions.py
+++ b/backend/accounts/services/badge_functions.py
@@ -36,16 +36,16 @@ def award_all_badges(user) -> None:
 # 회원가입 직후
 def award_signup_badges(user) -> None:
     with transaction.atomic():
-        _grant(user, "achieve", ACH_START, moathon=None)
+        _grant(user, "achieve", ACH_START)
 
 # 모아톤 생성 직후(티끌 모아 태산, 억만장자의 꿈)
 def award_achieve_badges_on_moathon_created(user, moathon: Moathon) -> None:
     with transaction.atomic():
-        _grant(user, "achieve", ACH_DEPOSIT, moathon=moathon)
+        _grant(user, "achieve", ACH_DEPOSIT)
 
         term_months = _get_term_months_by_save_trm(moathon)
         if term_months is not None and term_months >= 36:
-            _grant(user, "achieve", ACH_BILLIONAIRE, moathon=moathon)
+            _grant(user, "achieve", ACH_BILLIONAIRE)
 
 
 def award_track_badges(user) -> None:
@@ -57,13 +57,13 @@ def award_track_badges(user) -> None:
 
         # 누적 지급 방식
         if progress >= 25:
-            _grant(user, "track", TRACK_25, moathon=m)
+            _grant_track(user, "track", TRACK_25, moathon=m)
         if progress >= 50:
-            _grant(user, "track", TRACK_50, moathon=m)
+            _grant_track(user, "track", TRACK_50, moathon=m)
         if progress >= 75:
-            _grant(user, "track", TRACK_75, moathon=m)
+            _grant_track(user, "track", TRACK_75, moathon=m)
         if progress >= 100:
-            _grant(user, "track", TRACK_100, moathon=m)
+            _grant_track(user, "track", TRACK_100, moathon=m)
 
 
 def award_achieve_badges(user) -> None:
@@ -73,34 +73,34 @@ def award_achieve_badges(user) -> None:
     # 작심삼일 탈출(모아톤별)
     for m in moathons:
         if _maintained_days(m, today=today) >= 3:
-            _grant(user, "achieve", ACH_3DAYS, moathon=m)
+            _grant(user, "achieve", ACH_3DAYS)
 
     # 프로 완주러(유저당 1회)
     expired_cnt = Moathon.objects.filter(user=user, end_date__lt=today).count()
     if expired_cnt >= 3:
-        _grant(user, "achieve", ACH_PRO, moathon=None)
+        _grant(user, "achieve", ACH_PRO)
 
 
 def award_social_badges(user) -> None:
     # 소통요정: 내가 작성한 댓글 5개 이상
     my_comment_cnt = MoathonComment.objects.filter(user=user).count()
     if my_comment_cnt >= 5:
-        _grant(user, "social", SOC_COMMENTS, moathon=None)
+        _grant(user, "social", SOC_COMMENTS)
 
     # 응원단장: 내가 타인 모아톤에 누른 좋아요 10회
     cheer_cnt = MoathonLike.objects.filter(user=user).exclude(moathon__user=user).count()
     if cheer_cnt >= 10:
-        _grant(user, "social", SOC_CHEERLEADER, moathon=None)
+        _grant(user, "social", SOC_CHEERLEADER)
 
     # 인기스타: 내 모아톤이 받은 좋아요 20개
     beloved_cnt = MoathonLike.objects.filter(moathon__user=user).exclude(user=user).count()
     if beloved_cnt >= 20:
-        _grant(user, "social", SOC_BELOVED, moathon=None)
+        _grant(user, "social", SOC_BELOVED)
 
     # 팔로팔로미: 팔로워 10명
     follower_cnt = UserFollow.objects.filter(following=user).count()
     if follower_cnt >= 10:
-        _grant(user, "social", SOC_FOLLOWERS, moathon=None)
+        _grant(user, "social", SOC_FOLLOWERS)
 
 
 def _progress_rate(moathon: Moathon, today: date) -> int:
@@ -140,12 +140,22 @@ def _get_badge(badge_type: str, badge_name: str) -> Optional[Badge]:
         return None
 
 
-def _grant(user, badge_type: str, badge_name: str, moathon=None) -> None:
+def _grant_track(user, badge_type: str, badge_name: str, moathon=None) -> None:
     badge = _get_badge(badge_type, badge_name)
     if not badge:
         return
 
     try:
         UserBadge.objects.get_or_create(user=user, badge=badge, moathon=moathon)
+    except IntegrityError:
+        pass
+
+def _grant(user, badge_type: str, badge_name: str) -> None:
+    badge = _get_badge(badge_type, badge_name)
+    if not badge:
+        return
+
+    try:
+        UserBadge.objects.get_or_create(user=user, badge=badge)
     except IntegrityError:
         pass

--- a/backend/challenges/fixtures/challenges/challenges_social.json
+++ b/backend/challenges/fixtures/challenges/challenges_social.json
@@ -1,0 +1,2007 @@
+[
+{
+  "model": "challenges.moathoncomment",
+  "pk": 1,
+  "fields": {
+    "moathon": 73,
+    "user": 27,
+    "content": "꾸준함이 답이죠!",
+    "created_at": "2025-12-24T02:38:34.631Z",
+    "updated_at": "2025-12-24T02:38:34.631Z"
+  }
+},
+{
+  "model": "challenges.moathoncomment",
+  "pk": 2,
+  "fields": {
+    "moathon": 41,
+    "user": 27,
+    "content": "이번 주 루틴 정말 좋네요.",
+    "created_at": "2025-12-24T02:38:34.632Z",
+    "updated_at": "2025-12-24T02:38:34.632Z"
+  }
+},
+{
+  "model": "challenges.moathoncomment",
+  "pk": 3,
+  "fields": {
+    "moathon": 84,
+    "user": 27,
+    "content": "저도 자극받고 갑니다.",
+    "created_at": "2025-12-24T02:38:34.632Z",
+    "updated_at": "2025-12-24T02:38:34.632Z"
+  }
+},
+{
+  "model": "challenges.moathoncomment",
+  "pk": 4,
+  "fields": {
+    "moathon": 51,
+    "user": 27,
+    "content": "꾸준함이 답이죠!",
+    "created_at": "2025-12-24T02:38:34.632Z",
+    "updated_at": "2025-12-24T02:38:34.632Z"
+  }
+},
+{
+  "model": "challenges.moathoncomment",
+  "pk": 5,
+  "fields": {
+    "moathon": 59,
+    "user": 27,
+    "content": "이번 주 루틴 정말 좋네요.",
+    "created_at": "2025-12-24T02:38:34.632Z",
+    "updated_at": "2025-12-24T02:38:34.632Z"
+  }
+},
+{
+  "model": "challenges.moathoncomment",
+  "pk": 6,
+  "fields": {
+    "moathon": 34,
+    "user": 27,
+    "content": "이번 주 루틴 정말 좋네요.",
+    "created_at": "2025-12-24T02:38:34.633Z",
+    "updated_at": "2025-12-24T02:38:34.633Z"
+  }
+},
+{
+  "model": "challenges.moathoncomment",
+  "pk": 7,
+  "fields": {
+    "moathon": 32,
+    "user": 27,
+    "content": "꾸준함이 답이죠!",
+    "created_at": "2025-12-24T02:38:34.633Z",
+    "updated_at": "2025-12-24T02:38:34.633Z"
+  }
+},
+{
+  "model": "challenges.moathoncomment",
+  "pk": 8,
+  "fields": {
+    "moathon": 69,
+    "user": 11,
+    "content": "목표까지 꾸준히 가봅시다.",
+    "created_at": "2025-12-24T02:38:34.633Z",
+    "updated_at": "2025-12-24T02:38:34.633Z"
+  }
+},
+{
+  "model": "challenges.moathoncomment",
+  "pk": 9,
+  "fields": {
+    "moathon": 96,
+    "user": 11,
+    "content": "진행률 멋져요. 화이팅!",
+    "created_at": "2025-12-24T02:38:34.633Z",
+    "updated_at": "2025-12-24T02:38:34.633Z"
+  }
+},
+{
+  "model": "challenges.moathoncomment",
+  "pk": 10,
+  "fields": {
+    "moathon": 55,
+    "user": 11,
+    "content": "진행률 멋져요. 화이팅!",
+    "created_at": "2025-12-24T02:38:34.634Z",
+    "updated_at": "2025-12-24T02:38:34.634Z"
+  }
+},
+{
+  "model": "challenges.moathoncomment",
+  "pk": 11,
+  "fields": {
+    "moathon": 52,
+    "user": 11,
+    "content": "목표까지 꾸준히 가봅시다.",
+    "created_at": "2025-12-24T02:38:34.634Z",
+    "updated_at": "2025-12-24T02:38:34.634Z"
+  }
+},
+{
+  "model": "challenges.moathoncomment",
+  "pk": 12,
+  "fields": {
+    "moathon": 29,
+    "user": 11,
+    "content": "이번 주 루틴 정말 좋네요.",
+    "created_at": "2025-12-24T02:38:34.634Z",
+    "updated_at": "2025-12-24T02:38:34.634Z"
+  }
+},
+{
+  "model": "challenges.moathoncomment",
+  "pk": 13,
+  "fields": {
+    "moathon": 66,
+    "user": 11,
+    "content": "저도 자극받고 갑니다.",
+    "created_at": "2025-12-24T02:38:34.634Z",
+    "updated_at": "2025-12-24T02:38:34.634Z"
+  }
+},
+{
+  "model": "challenges.moathoncomment",
+  "pk": 14,
+  "fields": {
+    "moathon": 12,
+    "user": 11,
+    "content": "응원합니다! 같이 완주해요.",
+    "created_at": "2025-12-24T02:38:34.635Z",
+    "updated_at": "2025-12-24T02:38:34.635Z"
+  }
+},
+{
+  "model": "challenges.moathoncomment",
+  "pk": 15,
+  "fields": {
+    "moathon": 15,
+    "user": 11,
+    "content": "이번 주 루틴 정말 좋네요.",
+    "created_at": "2025-12-24T02:38:34.635Z",
+    "updated_at": "2025-12-24T02:38:34.635Z"
+  }
+},
+{
+  "model": "challenges.moathoncomment",
+  "pk": 16,
+  "fields": {
+    "moathon": 81,
+    "user": 11,
+    "content": "이번 주 루틴 정말 좋네요.",
+    "created_at": "2025-12-24T02:38:34.635Z",
+    "updated_at": "2025-12-24T02:38:34.635Z"
+  }
+},
+{
+  "model": "challenges.moathoncomment",
+  "pk": 17,
+  "fields": {
+    "moathon": 88,
+    "user": 11,
+    "content": "저도 자극받고 갑니다.",
+    "created_at": "2025-12-24T02:38:34.635Z",
+    "updated_at": "2025-12-24T02:38:34.635Z"
+  }
+},
+{
+  "model": "challenges.moathoncomment",
+  "pk": 18,
+  "fields": {
+    "moathon": 9,
+    "user": 10,
+    "content": "저도 자극받고 갑니다.",
+    "created_at": "2025-12-24T02:38:34.635Z",
+    "updated_at": "2025-12-24T02:38:34.636Z"
+  }
+},
+{
+  "model": "challenges.moathoncomment",
+  "pk": 19,
+  "fields": {
+    "moathon": 49,
+    "user": 10,
+    "content": "진행률 멋져요. 화이팅!",
+    "created_at": "2025-12-24T02:38:34.636Z",
+    "updated_at": "2025-12-24T02:38:34.636Z"
+  }
+},
+{
+  "model": "challenges.moathoncomment",
+  "pk": 20,
+  "fields": {
+    "moathon": 60,
+    "user": 10,
+    "content": "진행률 멋져요. 화이팅!",
+    "created_at": "2025-12-24T02:38:34.636Z",
+    "updated_at": "2025-12-24T02:38:34.636Z"
+  }
+},
+{
+  "model": "challenges.moathoncomment",
+  "pk": 21,
+  "fields": {
+    "moathon": 33,
+    "user": 10,
+    "content": "진행률 멋져요. 화이팅!",
+    "created_at": "2025-12-24T02:38:34.636Z",
+    "updated_at": "2025-12-24T02:38:34.636Z"
+  }
+},
+{
+  "model": "challenges.moathoncomment",
+  "pk": 22,
+  "fields": {
+    "moathon": 2,
+    "user": 10,
+    "content": "꾸준함이 답이죠!",
+    "created_at": "2025-12-24T02:38:34.636Z",
+    "updated_at": "2025-12-24T02:38:34.636Z"
+  }
+},
+{
+  "model": "challenges.moathoncomment",
+  "pk": 23,
+  "fields": {
+    "moathon": 93,
+    "user": 10,
+    "content": "응원합니다! 같이 완주해요.",
+    "created_at": "2025-12-24T02:38:34.637Z",
+    "updated_at": "2025-12-24T02:38:34.637Z"
+  }
+},
+{
+  "model": "challenges.moathoncomment",
+  "pk": 24,
+  "fields": {
+    "moathon": 88,
+    "user": 10,
+    "content": "진행률 멋져요. 화이팅!",
+    "created_at": "2025-12-24T02:38:34.637Z",
+    "updated_at": "2025-12-24T02:38:34.637Z"
+  }
+},
+{
+  "model": "challenges.moathoncomment",
+  "pk": 25,
+  "fields": {
+    "moathon": 97,
+    "user": 10,
+    "content": "목표까지 꾸준히 가봅시다.",
+    "created_at": "2025-12-24T02:38:34.637Z",
+    "updated_at": "2025-12-24T02:38:34.637Z"
+  }
+},
+{
+  "model": "challenges.moathoncomment",
+  "pk": 26,
+  "fields": {
+    "moathon": 99,
+    "user": 10,
+    "content": "꾸준함이 답이죠!",
+    "created_at": "2025-12-24T02:38:34.637Z",
+    "updated_at": "2025-12-24T02:38:34.637Z"
+  }
+},
+{
+  "model": "challenges.moathoncomment",
+  "pk": 27,
+  "fields": {
+    "moathon": 44,
+    "user": 10,
+    "content": "응원합니다! 같이 완주해요.",
+    "created_at": "2025-12-24T02:38:34.638Z",
+    "updated_at": "2025-12-24T02:38:34.638Z"
+  }
+},
+{
+  "model": "challenges.moathoncomment",
+  "pk": 28,
+  "fields": {
+    "moathon": 56,
+    "user": 28,
+    "content": "이번 주 루틴 정말 좋네요.",
+    "created_at": "2025-12-24T02:38:34.638Z",
+    "updated_at": "2025-12-24T02:38:34.638Z"
+  }
+},
+{
+  "model": "challenges.moathoncomment",
+  "pk": 29,
+  "fields": {
+    "moathon": 59,
+    "user": 28,
+    "content": "응원합니다! 같이 완주해요.",
+    "created_at": "2025-12-24T02:38:34.638Z",
+    "updated_at": "2025-12-24T02:38:34.638Z"
+  }
+},
+{
+  "model": "challenges.moathoncomment",
+  "pk": 30,
+  "fields": {
+    "moathon": 93,
+    "user": 28,
+    "content": "꾸준함이 답이죠!",
+    "created_at": "2025-12-24T02:38:34.638Z",
+    "updated_at": "2025-12-24T02:38:34.638Z"
+  }
+},
+{
+  "model": "challenges.moathoncomment",
+  "pk": 31,
+  "fields": {
+    "moathon": 34,
+    "user": 28,
+    "content": "진행률 멋져요. 화이팅!",
+    "created_at": "2025-12-24T02:38:34.638Z",
+    "updated_at": "2025-12-24T02:38:34.638Z"
+  }
+},
+{
+  "model": "challenges.moathoncomment",
+  "pk": 32,
+  "fields": {
+    "moathon": 98,
+    "user": 28,
+    "content": "이번 주 루틴 정말 좋네요.",
+    "created_at": "2025-12-24T02:38:34.639Z",
+    "updated_at": "2025-12-24T02:38:34.639Z"
+  }
+},
+{
+  "model": "challenges.moathoncomment",
+  "pk": 33,
+  "fields": {
+    "moathon": 65,
+    "user": 28,
+    "content": "응원합니다! 같이 완주해요.",
+    "created_at": "2025-12-24T02:38:34.639Z",
+    "updated_at": "2025-12-24T02:38:34.639Z"
+  }
+},
+{
+  "model": "challenges.moathoncomment",
+  "pk": 34,
+  "fields": {
+    "moathon": 81,
+    "user": 28,
+    "content": "목표까지 꾸준히 가봅시다.",
+    "created_at": "2025-12-24T02:38:34.639Z",
+    "updated_at": "2025-12-24T02:38:34.639Z"
+  }
+},
+{
+  "model": "challenges.moathoncomment",
+  "pk": 35,
+  "fields": {
+    "moathon": 82,
+    "user": 28,
+    "content": "진행률 멋져요. 화이팅!",
+    "created_at": "2025-12-24T02:38:34.639Z",
+    "updated_at": "2025-12-24T02:38:34.639Z"
+  }
+},
+{
+  "model": "challenges.moathoncomment",
+  "pk": 36,
+  "fields": {
+    "moathon": 26,
+    "user": 7,
+    "content": "이번 주 루틴 정말 좋네요.",
+    "created_at": "2025-12-24T02:38:34.640Z",
+    "updated_at": "2025-12-24T02:38:34.640Z"
+  }
+},
+{
+  "model": "challenges.moathoncomment",
+  "pk": 37,
+  "fields": {
+    "moathon": 48,
+    "user": 7,
+    "content": "이번 주 루틴 정말 좋네요.",
+    "created_at": "2025-12-24T02:38:34.640Z",
+    "updated_at": "2025-12-24T02:38:34.640Z"
+  }
+},
+{
+  "model": "challenges.moathoncomment",
+  "pk": 38,
+  "fields": {
+    "moathon": 70,
+    "user": 7,
+    "content": "진행률 멋져요. 화이팅!",
+    "created_at": "2025-12-24T02:38:34.640Z",
+    "updated_at": "2025-12-24T02:38:34.640Z"
+  }
+},
+{
+  "model": "challenges.moathoncomment",
+  "pk": 39,
+  "fields": {
+    "moathon": 1,
+    "user": 7,
+    "content": "진행률 멋져요. 화이팅!",
+    "created_at": "2025-12-24T02:38:34.640Z",
+    "updated_at": "2025-12-24T02:38:34.640Z"
+  }
+},
+{
+  "model": "challenges.moathoncomment",
+  "pk": 40,
+  "fields": {
+    "moathon": 42,
+    "user": 7,
+    "content": "저도 자극받고 갑니다.",
+    "created_at": "2025-12-24T02:38:34.641Z",
+    "updated_at": "2025-12-24T02:38:34.641Z"
+  }
+},
+{
+  "model": "challenges.moathoncomment",
+  "pk": 41,
+  "fields": {
+    "moathon": 3,
+    "user": 7,
+    "content": "응원합니다! 같이 완주해요.",
+    "created_at": "2025-12-24T02:38:34.641Z",
+    "updated_at": "2025-12-24T02:38:34.641Z"
+  }
+},
+{
+  "model": "challenges.moathoncomment",
+  "pk": 42,
+  "fields": {
+    "moathon": 47,
+    "user": 7,
+    "content": "목표까지 꾸준히 가봅시다.",
+    "created_at": "2025-12-24T02:38:34.641Z",
+    "updated_at": "2025-12-24T02:38:34.641Z"
+  }
+},
+{
+  "model": "challenges.moathoncomment",
+  "pk": 43,
+  "fields": {
+    "moathon": 31,
+    "user": 7,
+    "content": "응원합니다! 같이 완주해요.",
+    "created_at": "2025-12-24T02:38:34.641Z",
+    "updated_at": "2025-12-24T02:38:34.641Z"
+  }
+},
+{
+  "model": "challenges.moathoncomment",
+  "pk": 44,
+  "fields": {
+    "moathon": 31,
+    "user": 7,
+    "content": "진행률 멋져요. 화이팅!",
+    "created_at": "2025-12-24T02:38:34.642Z",
+    "updated_at": "2025-12-24T02:38:34.642Z"
+  }
+},
+{
+  "model": "challenges.moathoncomment",
+  "pk": 45,
+  "fields": {
+    "moathon": 11,
+    "user": 7,
+    "content": "응원합니다! 같이 완주해요.",
+    "created_at": "2025-12-24T02:38:34.642Z",
+    "updated_at": "2025-12-24T02:38:34.642Z"
+  }
+},
+{
+  "model": "challenges.moathoncomment",
+  "pk": 46,
+  "fields": {
+    "moathon": 63,
+    "user": 6,
+    "content": "응원합니다! 같이 완주해요.",
+    "created_at": "2025-12-24T02:38:34.642Z",
+    "updated_at": "2025-12-24T02:38:34.642Z"
+  }
+},
+{
+  "model": "challenges.moathoncomment",
+  "pk": 47,
+  "fields": {
+    "moathon": 98,
+    "user": 6,
+    "content": "진행률 멋져요. 화이팅!",
+    "created_at": "2025-12-24T02:38:34.642Z",
+    "updated_at": "2025-12-24T02:38:34.642Z"
+  }
+},
+{
+  "model": "challenges.moathoncomment",
+  "pk": 48,
+  "fields": {
+    "moathon": 99,
+    "user": 6,
+    "content": "이번 주 루틴 정말 좋네요.",
+    "created_at": "2025-12-24T02:38:34.642Z",
+    "updated_at": "2025-12-24T02:38:34.642Z"
+  }
+},
+{
+  "model": "challenges.moathoncomment",
+  "pk": 49,
+  "fields": {
+    "moathon": 17,
+    "user": 6,
+    "content": "꾸준함이 답이죠!",
+    "created_at": "2025-12-24T02:38:34.643Z",
+    "updated_at": "2025-12-24T02:38:34.643Z"
+  }
+},
+{
+  "model": "challenges.moathoncomment",
+  "pk": 50,
+  "fields": {
+    "moathon": 61,
+    "user": 6,
+    "content": "진행률 멋져요. 화이팅!",
+    "created_at": "2025-12-24T02:38:34.643Z",
+    "updated_at": "2025-12-24T02:38:34.643Z"
+  }
+},
+{
+  "model": "challenges.moathoncomment",
+  "pk": 51,
+  "fields": {
+    "moathon": 22,
+    "user": 6,
+    "content": "목표까지 꾸준히 가봅시다.",
+    "created_at": "2025-12-24T02:38:34.643Z",
+    "updated_at": "2025-12-24T02:38:34.643Z"
+  }
+},
+{
+  "model": "challenges.moathoncomment",
+  "pk": 52,
+  "fields": {
+    "moathon": 68,
+    "user": 6,
+    "content": "진행률 멋져요. 화이팅!",
+    "created_at": "2025-12-24T02:38:34.643Z",
+    "updated_at": "2025-12-24T02:38:34.643Z"
+  }
+},
+{
+  "model": "challenges.moathoncomment",
+  "pk": 53,
+  "fields": {
+    "moathon": 55,
+    "user": 6,
+    "content": "이번 주 루틴 정말 좋네요.",
+    "created_at": "2025-12-24T02:38:34.644Z",
+    "updated_at": "2025-12-24T02:38:34.644Z"
+  }
+},
+{
+  "model": "challenges.moathoncomment",
+  "pk": 54,
+  "fields": {
+    "moathon": 70,
+    "user": 6,
+    "content": "꾸준함이 답이죠!",
+    "created_at": "2025-12-24T02:38:34.644Z",
+    "updated_at": "2025-12-24T02:38:34.644Z"
+  }
+},
+{
+  "model": "challenges.moathoncomment",
+  "pk": 55,
+  "fields": {
+    "moathon": 89,
+    "user": 6,
+    "content": "이번 주 루틴 정말 좋네요.",
+    "created_at": "2025-12-24T02:38:34.644Z",
+    "updated_at": "2025-12-24T02:38:34.644Z"
+  }
+},
+{
+  "model": "challenges.moathoncomment",
+  "pk": 56,
+  "fields": {
+    "moathon": 92,
+    "user": 6,
+    "content": "목표까지 꾸준히 가봅시다.",
+    "created_at": "2025-12-24T02:38:34.644Z",
+    "updated_at": "2025-12-24T02:38:34.644Z"
+  }
+},
+{
+  "model": "challenges.moathoncomment",
+  "pk": 57,
+  "fields": {
+    "moathon": 86,
+    "user": 20,
+    "content": "꾸준함이 답이죠!",
+    "created_at": "2025-12-24T02:38:34.645Z",
+    "updated_at": "2025-12-24T02:38:34.645Z"
+  }
+},
+{
+  "model": "challenges.moathoncomment",
+  "pk": 58,
+  "fields": {
+    "moathon": 48,
+    "user": 20,
+    "content": "저도 자극받고 갑니다.",
+    "created_at": "2025-12-24T02:38:34.645Z",
+    "updated_at": "2025-12-24T02:38:34.645Z"
+  }
+},
+{
+  "model": "challenges.moathoncomment",
+  "pk": 59,
+  "fields": {
+    "moathon": 67,
+    "user": 20,
+    "content": "저도 자극받고 갑니다.",
+    "created_at": "2025-12-24T02:38:34.645Z",
+    "updated_at": "2025-12-24T02:38:34.645Z"
+  }
+},
+{
+  "model": "challenges.moathoncomment",
+  "pk": 60,
+  "fields": {
+    "moathon": 16,
+    "user": 20,
+    "content": "이번 주 루틴 정말 좋네요.",
+    "created_at": "2025-12-24T02:38:34.645Z",
+    "updated_at": "2025-12-24T02:38:34.645Z"
+  }
+},
+{
+  "model": "challenges.moathoncomment",
+  "pk": 61,
+  "fields": {
+    "moathon": 29,
+    "user": 20,
+    "content": "응원합니다! 같이 완주해요.",
+    "created_at": "2025-12-24T02:38:34.645Z",
+    "updated_at": "2025-12-24T02:38:34.645Z"
+  }
+},
+{
+  "model": "challenges.moathoncomment",
+  "pk": 62,
+  "fields": {
+    "moathon": 44,
+    "user": 20,
+    "content": "응원합니다! 같이 완주해요.",
+    "created_at": "2025-12-24T02:38:34.646Z",
+    "updated_at": "2025-12-24T02:38:34.646Z"
+  }
+},
+{
+  "model": "challenges.moathoncomment",
+  "pk": 63,
+  "fields": {
+    "moathon": 76,
+    "user": 20,
+    "content": "진행률 멋져요. 화이팅!",
+    "created_at": "2025-12-24T02:38:34.646Z",
+    "updated_at": "2025-12-24T02:38:34.646Z"
+  }
+},
+{
+  "model": "challenges.moathoncomment",
+  "pk": 64,
+  "fields": {
+    "moathon": 30,
+    "user": 20,
+    "content": "진행률 멋져요. 화이팅!",
+    "created_at": "2025-12-24T02:38:34.646Z",
+    "updated_at": "2025-12-24T02:38:34.646Z"
+  }
+},
+{
+  "model": "challenges.moathoncomment",
+  "pk": 65,
+  "fields": {
+    "moathon": 29,
+    "user": 20,
+    "content": "응원합니다! 같이 완주해요.",
+    "created_at": "2025-12-24T02:38:34.646Z",
+    "updated_at": "2025-12-24T02:38:34.646Z"
+  }
+},
+{
+  "model": "challenges.moathoncomment",
+  "pk": 66,
+  "fields": {
+    "moathon": 91,
+    "user": 5,
+    "content": "꾸준함이 답이죠!",
+    "created_at": "2025-12-24T02:38:34.647Z",
+    "updated_at": "2025-12-24T02:38:34.647Z"
+  }
+},
+{
+  "model": "challenges.moathoncomment",
+  "pk": 67,
+  "fields": {
+    "moathon": 8,
+    "user": 5,
+    "content": "이번 주 루틴 정말 좋네요.",
+    "created_at": "2025-12-24T02:38:34.647Z",
+    "updated_at": "2025-12-24T02:38:34.647Z"
+  }
+},
+{
+  "model": "challenges.moathoncomment",
+  "pk": 68,
+  "fields": {
+    "moathon": 9,
+    "user": 5,
+    "content": "응원합니다! 같이 완주해요.",
+    "created_at": "2025-12-24T02:38:34.647Z",
+    "updated_at": "2025-12-24T02:38:34.647Z"
+  }
+},
+{
+  "model": "challenges.moathoncomment",
+  "pk": 69,
+  "fields": {
+    "moathon": 43,
+    "user": 5,
+    "content": "응원합니다! 같이 완주해요.",
+    "created_at": "2025-12-24T02:38:34.647Z",
+    "updated_at": "2025-12-24T02:38:34.647Z"
+  }
+},
+{
+  "model": "challenges.moathoncomment",
+  "pk": 70,
+  "fields": {
+    "moathon": 66,
+    "user": 5,
+    "content": "이번 주 루틴 정말 좋네요.",
+    "created_at": "2025-12-24T02:38:34.647Z",
+    "updated_at": "2025-12-24T02:38:34.648Z"
+  }
+},
+{
+  "model": "challenges.moathoncomment",
+  "pk": 71,
+  "fields": {
+    "moathon": 36,
+    "user": 5,
+    "content": "꾸준함이 답이죠!",
+    "created_at": "2025-12-24T02:38:34.648Z",
+    "updated_at": "2025-12-24T02:38:34.648Z"
+  }
+},
+{
+  "model": "challenges.moathonlike",
+  "pk": 1,
+  "fields": {
+    "user": 22,
+    "moathon": 21,
+    "created_at": "2025-12-24T02:38:34.650Z"
+  }
+},
+{
+  "model": "challenges.moathonlike",
+  "pk": 2,
+  "fields": {
+    "user": 22,
+    "moathon": 40,
+    "created_at": "2025-12-24T02:38:34.651Z"
+  }
+},
+{
+  "model": "challenges.moathonlike",
+  "pk": 3,
+  "fields": {
+    "user": 22,
+    "moathon": 80,
+    "created_at": "2025-12-24T02:38:34.652Z"
+  }
+},
+{
+  "model": "challenges.moathonlike",
+  "pk": 4,
+  "fields": {
+    "user": 22,
+    "moathon": 48,
+    "created_at": "2025-12-24T02:38:34.653Z"
+  }
+},
+{
+  "model": "challenges.moathonlike",
+  "pk": 5,
+  "fields": {
+    "user": 22,
+    "moathon": 50,
+    "created_at": "2025-12-24T02:38:34.653Z"
+  }
+},
+{
+  "model": "challenges.moathonlike",
+  "pk": 6,
+  "fields": {
+    "user": 22,
+    "moathon": 12,
+    "created_at": "2025-12-24T02:38:34.654Z"
+  }
+},
+{
+  "model": "challenges.moathonlike",
+  "pk": 7,
+  "fields": {
+    "user": 22,
+    "moathon": 34,
+    "created_at": "2025-12-24T02:38:34.655Z"
+  }
+},
+{
+  "model": "challenges.moathonlike",
+  "pk": 8,
+  "fields": {
+    "user": 22,
+    "moathon": 51,
+    "created_at": "2025-12-24T02:38:34.656Z"
+  }
+},
+{
+  "model": "challenges.moathonlike",
+  "pk": 9,
+  "fields": {
+    "user": 22,
+    "moathon": 3,
+    "created_at": "2025-12-24T02:38:34.657Z"
+  }
+},
+{
+  "model": "challenges.moathonlike",
+  "pk": 10,
+  "fields": {
+    "user": 22,
+    "moathon": 54,
+    "created_at": "2025-12-24T02:38:34.658Z"
+  }
+},
+{
+  "model": "challenges.moathonlike",
+  "pk": 11,
+  "fields": {
+    "user": 22,
+    "moathon": 9,
+    "created_at": "2025-12-24T02:38:34.658Z"
+  }
+},
+{
+  "model": "challenges.moathonlike",
+  "pk": 12,
+  "fields": {
+    "user": 22,
+    "moathon": 79,
+    "created_at": "2025-12-24T02:38:34.659Z"
+  }
+},
+{
+  "model": "challenges.moathonlike",
+  "pk": 13,
+  "fields": {
+    "user": 16,
+    "moathon": 98,
+    "created_at": "2025-12-24T02:38:34.660Z"
+  }
+},
+{
+  "model": "challenges.moathonlike",
+  "pk": 14,
+  "fields": {
+    "user": 16,
+    "moathon": 4,
+    "created_at": "2025-12-24T02:38:34.661Z"
+  }
+},
+{
+  "model": "challenges.moathonlike",
+  "pk": 15,
+  "fields": {
+    "user": 16,
+    "moathon": 15,
+    "created_at": "2025-12-24T02:38:34.662Z"
+  }
+},
+{
+  "model": "challenges.moathonlike",
+  "pk": 16,
+  "fields": {
+    "user": 16,
+    "moathon": 37,
+    "created_at": "2025-12-24T02:38:34.662Z"
+  }
+},
+{
+  "model": "challenges.moathonlike",
+  "pk": 17,
+  "fields": {
+    "user": 16,
+    "moathon": 92,
+    "created_at": "2025-12-24T02:38:34.663Z"
+  }
+},
+{
+  "model": "challenges.moathonlike",
+  "pk": 18,
+  "fields": {
+    "user": 16,
+    "moathon": 26,
+    "created_at": "2025-12-24T02:38:34.664Z"
+  }
+},
+{
+  "model": "challenges.moathonlike",
+  "pk": 19,
+  "fields": {
+    "user": 16,
+    "moathon": 12,
+    "created_at": "2025-12-24T02:38:34.665Z"
+  }
+},
+{
+  "model": "challenges.moathonlike",
+  "pk": 20,
+  "fields": {
+    "user": 16,
+    "moathon": 93,
+    "created_at": "2025-12-24T02:38:34.666Z"
+  }
+},
+{
+  "model": "challenges.moathonlike",
+  "pk": 21,
+  "fields": {
+    "user": 16,
+    "moathon": 50,
+    "created_at": "2025-12-24T02:38:34.667Z"
+  }
+},
+{
+  "model": "challenges.moathonlike",
+  "pk": 22,
+  "fields": {
+    "user": 16,
+    "moathon": 86,
+    "created_at": "2025-12-24T02:38:34.667Z"
+  }
+},
+{
+  "model": "challenges.moathonlike",
+  "pk": 23,
+  "fields": {
+    "user": 16,
+    "moathon": 45,
+    "created_at": "2025-12-24T02:38:34.668Z"
+  }
+},
+{
+  "model": "challenges.moathonlike",
+  "pk": 24,
+  "fields": {
+    "user": 16,
+    "moathon": 71,
+    "created_at": "2025-12-24T02:38:34.669Z"
+  }
+},
+{
+  "model": "challenges.moathonlike",
+  "pk": 25,
+  "fields": {
+    "user": 3,
+    "moathon": 21,
+    "created_at": "2025-12-24T02:38:34.670Z"
+  }
+},
+{
+  "model": "challenges.moathonlike",
+  "pk": 26,
+  "fields": {
+    "user": 3,
+    "moathon": 43,
+    "created_at": "2025-12-24T02:38:34.671Z"
+  }
+},
+{
+  "model": "challenges.moathonlike",
+  "pk": 27,
+  "fields": {
+    "user": 3,
+    "moathon": 15,
+    "created_at": "2025-12-24T02:38:34.671Z"
+  }
+},
+{
+  "model": "challenges.moathonlike",
+  "pk": 28,
+  "fields": {
+    "user": 3,
+    "moathon": 98,
+    "created_at": "2025-12-24T02:38:34.672Z"
+  }
+},
+{
+  "model": "challenges.moathonlike",
+  "pk": 29,
+  "fields": {
+    "user": 3,
+    "moathon": 66,
+    "created_at": "2025-12-24T02:38:34.673Z"
+  }
+},
+{
+  "model": "challenges.moathonlike",
+  "pk": 30,
+  "fields": {
+    "user": 3,
+    "moathon": 68,
+    "created_at": "2025-12-24T02:38:34.674Z"
+  }
+},
+{
+  "model": "challenges.moathonlike",
+  "pk": 31,
+  "fields": {
+    "user": 3,
+    "moathon": 46,
+    "created_at": "2025-12-24T02:38:34.675Z"
+  }
+},
+{
+  "model": "challenges.moathonlike",
+  "pk": 32,
+  "fields": {
+    "user": 3,
+    "moathon": 44,
+    "created_at": "2025-12-24T02:38:34.675Z"
+  }
+},
+{
+  "model": "challenges.moathonlike",
+  "pk": 33,
+  "fields": {
+    "user": 3,
+    "moathon": 89,
+    "created_at": "2025-12-24T02:38:34.676Z"
+  }
+},
+{
+  "model": "challenges.moathonlike",
+  "pk": 34,
+  "fields": {
+    "user": 3,
+    "moathon": 70,
+    "created_at": "2025-12-24T02:38:34.677Z"
+  }
+},
+{
+  "model": "challenges.moathonlike",
+  "pk": 35,
+  "fields": {
+    "user": 3,
+    "moathon": 55,
+    "created_at": "2025-12-24T02:38:34.678Z"
+  }
+},
+{
+  "model": "challenges.moathonlike",
+  "pk": 36,
+  "fields": {
+    "user": 3,
+    "moathon": 42,
+    "created_at": "2025-12-24T02:38:34.678Z"
+  }
+},
+{
+  "model": "challenges.moathonlike",
+  "pk": 37,
+  "fields": {
+    "user": 2,
+    "moathon": 49,
+    "created_at": "2025-12-24T02:38:34.679Z"
+  }
+},
+{
+  "model": "challenges.moathonlike",
+  "pk": 38,
+  "fields": {
+    "user": 2,
+    "moathon": 64,
+    "created_at": "2025-12-24T02:38:34.680Z"
+  }
+},
+{
+  "model": "challenges.moathonlike",
+  "pk": 39,
+  "fields": {
+    "user": 2,
+    "moathon": 47,
+    "created_at": "2025-12-24T02:38:34.681Z"
+  }
+},
+{
+  "model": "challenges.moathonlike",
+  "pk": 40,
+  "fields": {
+    "user": 2,
+    "moathon": 60,
+    "created_at": "2025-12-24T02:38:34.682Z"
+  }
+},
+{
+  "model": "challenges.moathonlike",
+  "pk": 41,
+  "fields": {
+    "user": 2,
+    "moathon": 84,
+    "created_at": "2025-12-24T02:38:34.683Z"
+  }
+},
+{
+  "model": "challenges.moathonlike",
+  "pk": 42,
+  "fields": {
+    "user": 2,
+    "moathon": 70,
+    "created_at": "2025-12-24T02:38:34.683Z"
+  }
+},
+{
+  "model": "challenges.moathonlike",
+  "pk": 43,
+  "fields": {
+    "user": 2,
+    "moathon": 80,
+    "created_at": "2025-12-24T02:38:34.684Z"
+  }
+},
+{
+  "model": "challenges.moathonlike",
+  "pk": 44,
+  "fields": {
+    "user": 2,
+    "moathon": 74,
+    "created_at": "2025-12-24T02:38:34.685Z"
+  }
+},
+{
+  "model": "challenges.moathonlike",
+  "pk": 45,
+  "fields": {
+    "user": 2,
+    "moathon": 37,
+    "created_at": "2025-12-24T02:38:34.686Z"
+  }
+},
+{
+  "model": "challenges.moathonlike",
+  "pk": 46,
+  "fields": {
+    "user": 2,
+    "moathon": 83,
+    "created_at": "2025-12-24T02:38:34.687Z"
+  }
+},
+{
+  "model": "challenges.moathonlike",
+  "pk": 47,
+  "fields": {
+    "user": 2,
+    "moathon": 11,
+    "created_at": "2025-12-24T02:38:34.687Z"
+  }
+},
+{
+  "model": "challenges.moathonlike",
+  "pk": 48,
+  "fields": {
+    "user": 2,
+    "moathon": 14,
+    "created_at": "2025-12-24T02:38:34.688Z"
+  }
+},
+{
+  "model": "challenges.moathonlike",
+  "pk": 49,
+  "fields": {
+    "user": 5,
+    "moathon": 55,
+    "created_at": "2025-12-24T02:38:34.689Z"
+  }
+},
+{
+  "model": "challenges.moathonlike",
+  "pk": 50,
+  "fields": {
+    "user": 5,
+    "moathon": 92,
+    "created_at": "2025-12-24T02:38:34.690Z"
+  }
+},
+{
+  "model": "challenges.moathonlike",
+  "pk": 51,
+  "fields": {
+    "user": 5,
+    "moathon": 71,
+    "created_at": "2025-12-24T02:38:34.691Z"
+  }
+},
+{
+  "model": "challenges.moathonlike",
+  "pk": 52,
+  "fields": {
+    "user": 5,
+    "moathon": 50,
+    "created_at": "2025-12-24T02:38:34.691Z"
+  }
+},
+{
+  "model": "challenges.moathonlike",
+  "pk": 53,
+  "fields": {
+    "user": 5,
+    "moathon": 97,
+    "created_at": "2025-12-24T02:38:34.692Z"
+  }
+},
+{
+  "model": "challenges.moathonlike",
+  "pk": 54,
+  "fields": {
+    "user": 5,
+    "moathon": 45,
+    "created_at": "2025-12-24T02:38:34.693Z"
+  }
+},
+{
+  "model": "challenges.moathonlike",
+  "pk": 55,
+  "fields": {
+    "user": 5,
+    "moathon": 4,
+    "created_at": "2025-12-24T02:38:34.694Z"
+  }
+},
+{
+  "model": "challenges.moathonlike",
+  "pk": 56,
+  "fields": {
+    "user": 5,
+    "moathon": 87,
+    "created_at": "2025-12-24T02:38:34.695Z"
+  }
+},
+{
+  "model": "challenges.moathonlike",
+  "pk": 57,
+  "fields": {
+    "user": 5,
+    "moathon": 75,
+    "created_at": "2025-12-24T02:38:34.696Z"
+  }
+},
+{
+  "model": "challenges.moathonlike",
+  "pk": 58,
+  "fields": {
+    "user": 5,
+    "moathon": 15,
+    "created_at": "2025-12-24T02:38:34.696Z"
+  }
+},
+{
+  "model": "challenges.moathonlike",
+  "pk": 59,
+  "fields": {
+    "user": 5,
+    "moathon": 27,
+    "created_at": "2025-12-24T02:38:34.697Z"
+  }
+},
+{
+  "model": "challenges.moathonlike",
+  "pk": 60,
+  "fields": {
+    "user": 5,
+    "moathon": 20,
+    "created_at": "2025-12-24T02:38:34.698Z"
+  }
+},
+{
+  "model": "challenges.moathonlike",
+  "pk": 61,
+  "fields": {
+    "user": 9,
+    "moathon": 34,
+    "created_at": "2025-12-24T02:38:34.699Z"
+  }
+},
+{
+  "model": "challenges.moathonlike",
+  "pk": 62,
+  "fields": {
+    "user": 9,
+    "moathon": 51,
+    "created_at": "2025-12-24T02:38:34.700Z"
+  }
+},
+{
+  "model": "challenges.moathonlike",
+  "pk": 63,
+  "fields": {
+    "user": 9,
+    "moathon": 39,
+    "created_at": "2025-12-24T02:38:34.700Z"
+  }
+},
+{
+  "model": "challenges.moathonlike",
+  "pk": 64,
+  "fields": {
+    "user": 9,
+    "moathon": 68,
+    "created_at": "2025-12-24T02:38:34.701Z"
+  }
+},
+{
+  "model": "challenges.moathonlike",
+  "pk": 65,
+  "fields": {
+    "user": 9,
+    "moathon": 2,
+    "created_at": "2025-12-24T02:38:34.702Z"
+  }
+},
+{
+  "model": "challenges.moathonlike",
+  "pk": 66,
+  "fields": {
+    "user": 9,
+    "moathon": 58,
+    "created_at": "2025-12-24T02:38:34.703Z"
+  }
+},
+{
+  "model": "challenges.moathonlike",
+  "pk": 67,
+  "fields": {
+    "user": 9,
+    "moathon": 76,
+    "created_at": "2025-12-24T02:38:34.704Z"
+  }
+},
+{
+  "model": "challenges.moathonlike",
+  "pk": 68,
+  "fields": {
+    "user": 9,
+    "moathon": 64,
+    "created_at": "2025-12-24T02:38:34.704Z"
+  }
+},
+{
+  "model": "challenges.moathonlike",
+  "pk": 69,
+  "fields": {
+    "user": 9,
+    "moathon": 97,
+    "created_at": "2025-12-24T02:38:34.705Z"
+  }
+},
+{
+  "model": "challenges.moathonlike",
+  "pk": 70,
+  "fields": {
+    "user": 9,
+    "moathon": 63,
+    "created_at": "2025-12-24T02:38:34.706Z"
+  }
+},
+{
+  "model": "challenges.moathonlike",
+  "pk": 71,
+  "fields": {
+    "user": 9,
+    "moathon": 79,
+    "created_at": "2025-12-24T02:38:34.707Z"
+  }
+},
+{
+  "model": "challenges.moathonlike",
+  "pk": 72,
+  "fields": {
+    "user": 9,
+    "moathon": 98,
+    "created_at": "2025-12-24T02:38:34.707Z"
+  }
+},
+{
+  "model": "challenges.moathonlike",
+  "pk": 73,
+  "fields": {
+    "user": 26,
+    "moathon": 66,
+    "created_at": "2025-12-24T02:38:34.708Z"
+  }
+},
+{
+  "model": "challenges.moathonlike",
+  "pk": 74,
+  "fields": {
+    "user": 22,
+    "moathon": 66,
+    "created_at": "2025-12-24T02:38:34.709Z"
+  }
+},
+{
+  "model": "challenges.moathonlike",
+  "pk": 75,
+  "fields": {
+    "user": 5,
+    "moathon": 66,
+    "created_at": "2025-12-24T02:38:34.709Z"
+  }
+},
+{
+  "model": "challenges.moathonlike",
+  "pk": 76,
+  "fields": {
+    "user": 6,
+    "moathon": 66,
+    "created_at": "2025-12-24T02:38:34.710Z"
+  }
+},
+{
+  "model": "challenges.moathonlike",
+  "pk": 77,
+  "fields": {
+    "user": 4,
+    "moathon": 66,
+    "created_at": "2025-12-24T02:38:34.711Z"
+  }
+},
+{
+  "model": "challenges.moathonlike",
+  "pk": 78,
+  "fields": {
+    "user": 10,
+    "moathon": 66,
+    "created_at": "2025-12-24T02:38:34.712Z"
+  }
+},
+{
+  "model": "challenges.moathonlike",
+  "pk": 79,
+  "fields": {
+    "user": 28,
+    "moathon": 66,
+    "created_at": "2025-12-24T02:38:34.713Z"
+  }
+},
+{
+  "model": "challenges.moathonlike",
+  "pk": 80,
+  "fields": {
+    "user": 2,
+    "moathon": 66,
+    "created_at": "2025-12-24T02:38:34.714Z"
+  }
+},
+{
+  "model": "challenges.moathonlike",
+  "pk": 81,
+  "fields": {
+    "user": 27,
+    "moathon": 66,
+    "created_at": "2025-12-24T02:38:34.714Z"
+  }
+},
+{
+  "model": "challenges.moathonlike",
+  "pk": 82,
+  "fields": {
+    "user": 13,
+    "moathon": 66,
+    "created_at": "2025-12-24T02:38:34.715Z"
+  }
+},
+{
+  "model": "challenges.moathonlike",
+  "pk": 83,
+  "fields": {
+    "user": 25,
+    "moathon": 66,
+    "created_at": "2025-12-24T02:38:34.716Z"
+  }
+},
+{
+  "model": "challenges.moathonlike",
+  "pk": 84,
+  "fields": {
+    "user": 15,
+    "moathon": 66,
+    "created_at": "2025-12-24T02:38:34.717Z"
+  }
+},
+{
+  "model": "challenges.moathonlike",
+  "pk": 85,
+  "fields": {
+    "user": 30,
+    "moathon": 66,
+    "created_at": "2025-12-24T02:38:34.718Z"
+  }
+},
+{
+  "model": "challenges.moathonlike",
+  "pk": 86,
+  "fields": {
+    "user": 23,
+    "moathon": 66,
+    "created_at": "2025-12-24T02:38:34.718Z"
+  }
+},
+{
+  "model": "challenges.moathonlike",
+  "pk": 87,
+  "fields": {
+    "user": 12,
+    "moathon": 66,
+    "created_at": "2025-12-24T02:38:34.719Z"
+  }
+},
+{
+  "model": "challenges.moathonlike",
+  "pk": 88,
+  "fields": {
+    "user": 19,
+    "moathon": 66,
+    "created_at": "2025-12-24T02:38:34.720Z"
+  }
+},
+{
+  "model": "challenges.moathonlike",
+  "pk": 89,
+  "fields": {
+    "user": 16,
+    "moathon": 66,
+    "created_at": "2025-12-24T02:38:34.721Z"
+  }
+},
+{
+  "model": "challenges.moathonlike",
+  "pk": 90,
+  "fields": {
+    "user": 14,
+    "moathon": 66,
+    "created_at": "2025-12-24T02:38:34.721Z"
+  }
+},
+{
+  "model": "challenges.moathonlike",
+  "pk": 91,
+  "fields": {
+    "user": 8,
+    "moathon": 66,
+    "created_at": "2025-12-24T02:38:34.722Z"
+  }
+},
+{
+  "model": "challenges.moathonlike",
+  "pk": 92,
+  "fields": {
+    "user": 7,
+    "moathon": 66,
+    "created_at": "2025-12-24T02:38:34.723Z"
+  }
+},
+{
+  "model": "challenges.moathonlike",
+  "pk": 93,
+  "fields": {
+    "user": 17,
+    "moathon": 66,
+    "created_at": "2025-12-24T02:38:34.724Z"
+  }
+},
+{
+  "model": "challenges.moathonlike",
+  "pk": 94,
+  "fields": {
+    "user": 22,
+    "moathon": 11,
+    "created_at": "2025-12-24T02:38:34.725Z"
+  }
+},
+{
+  "model": "challenges.moathonlike",
+  "pk": 95,
+  "fields": {
+    "user": 8,
+    "moathon": 11,
+    "created_at": "2025-12-24T02:38:34.726Z"
+  }
+},
+{
+  "model": "challenges.moathonlike",
+  "pk": 96,
+  "fields": {
+    "user": 1,
+    "moathon": 11,
+    "created_at": "2025-12-24T02:38:34.727Z"
+  }
+},
+{
+  "model": "challenges.moathonlike",
+  "pk": 97,
+  "fields": {
+    "user": 6,
+    "moathon": 11,
+    "created_at": "2025-12-24T02:38:34.728Z"
+  }
+},
+{
+  "model": "challenges.moathonlike",
+  "pk": 98,
+  "fields": {
+    "user": 20,
+    "moathon": 11,
+    "created_at": "2025-12-24T02:38:34.728Z"
+  }
+},
+{
+  "model": "challenges.moathonlike",
+  "pk": 99,
+  "fields": {
+    "user": 29,
+    "moathon": 11,
+    "created_at": "2025-12-24T02:38:34.729Z"
+  }
+},
+{
+  "model": "challenges.moathonlike",
+  "pk": 100,
+  "fields": {
+    "user": 14,
+    "moathon": 11,
+    "created_at": "2025-12-24T02:38:34.730Z"
+  }
+},
+{
+  "model": "challenges.moathonlike",
+  "pk": 101,
+  "fields": {
+    "user": 24,
+    "moathon": 11,
+    "created_at": "2025-12-24T02:38:34.731Z"
+  }
+},
+{
+  "model": "challenges.moathonlike",
+  "pk": 102,
+  "fields": {
+    "user": 27,
+    "moathon": 11,
+    "created_at": "2025-12-24T02:38:34.732Z"
+  }
+},
+{
+  "model": "challenges.moathonlike",
+  "pk": 103,
+  "fields": {
+    "user": 3,
+    "moathon": 11,
+    "created_at": "2025-12-24T02:38:34.732Z"
+  }
+},
+{
+  "model": "challenges.moathonlike",
+  "pk": 104,
+  "fields": {
+    "user": 26,
+    "moathon": 11,
+    "created_at": "2025-12-24T02:38:34.733Z"
+  }
+},
+{
+  "model": "challenges.moathonlike",
+  "pk": 105,
+  "fields": {
+    "user": 7,
+    "moathon": 11,
+    "created_at": "2025-12-24T02:38:34.734Z"
+  }
+},
+{
+  "model": "challenges.moathonlike",
+  "pk": 106,
+  "fields": {
+    "user": 17,
+    "moathon": 11,
+    "created_at": "2025-12-24T02:38:34.735Z"
+  }
+},
+{
+  "model": "challenges.moathonlike",
+  "pk": 107,
+  "fields": {
+    "user": 23,
+    "moathon": 11,
+    "created_at": "2025-12-24T02:38:34.736Z"
+  }
+},
+{
+  "model": "challenges.moathonlike",
+  "pk": 108,
+  "fields": {
+    "user": 5,
+    "moathon": 11,
+    "created_at": "2025-12-24T02:38:34.737Z"
+  }
+},
+{
+  "model": "challenges.moathonlike",
+  "pk": 109,
+  "fields": {
+    "user": 9,
+    "moathon": 11,
+    "created_at": "2025-12-24T02:38:34.738Z"
+  }
+},
+{
+  "model": "challenges.moathonlike",
+  "pk": 110,
+  "fields": {
+    "user": 21,
+    "moathon": 11,
+    "created_at": "2025-12-24T02:38:34.738Z"
+  }
+},
+{
+  "model": "challenges.moathonlike",
+  "pk": 111,
+  "fields": {
+    "user": 11,
+    "moathon": 11,
+    "created_at": "2025-12-24T02:38:34.739Z"
+  }
+},
+{
+  "model": "challenges.moathonlike",
+  "pk": 112,
+  "fields": {
+    "user": 10,
+    "moathon": 11,
+    "created_at": "2025-12-24T02:38:34.740Z"
+  }
+},
+{
+  "model": "challenges.moathonlike",
+  "pk": 113,
+  "fields": {
+    "user": 16,
+    "moathon": 11,
+    "created_at": "2025-12-24T02:38:34.741Z"
+  }
+},
+{
+  "model": "challenges.moathonlike",
+  "pk": 114,
+  "fields": {
+    "user": 28,
+    "moathon": 11,
+    "created_at": "2025-12-24T02:38:34.741Z"
+  }
+},
+{
+  "model": "challenges.moathonlike",
+  "pk": 115,
+  "fields": {
+    "user": 22,
+    "moathon": 2,
+    "created_at": "2025-12-24T02:38:34.742Z"
+  }
+},
+{
+  "model": "challenges.moathonlike",
+  "pk": 116,
+  "fields": {
+    "user": 28,
+    "moathon": 2,
+    "created_at": "2025-12-24T02:38:34.743Z"
+  }
+},
+{
+  "model": "challenges.moathonlike",
+  "pk": 117,
+  "fields": {
+    "user": 18,
+    "moathon": 2,
+    "created_at": "2025-12-24T02:38:34.744Z"
+  }
+},
+{
+  "model": "challenges.moathonlike",
+  "pk": 118,
+  "fields": {
+    "user": 16,
+    "moathon": 2,
+    "created_at": "2025-12-24T02:38:34.745Z"
+  }
+},
+{
+  "model": "challenges.moathonlike",
+  "pk": 119,
+  "fields": {
+    "user": 4,
+    "moathon": 2,
+    "created_at": "2025-12-24T02:38:34.746Z"
+  }
+},
+{
+  "model": "challenges.moathonlike",
+  "pk": 120,
+  "fields": {
+    "user": 8,
+    "moathon": 2,
+    "created_at": "2025-12-24T02:38:34.747Z"
+  }
+},
+{
+  "model": "challenges.moathonlike",
+  "pk": 121,
+  "fields": {
+    "user": 5,
+    "moathon": 2,
+    "created_at": "2025-12-24T02:38:34.747Z"
+  }
+},
+{
+  "model": "challenges.moathonlike",
+  "pk": 122,
+  "fields": {
+    "user": 29,
+    "moathon": 2,
+    "created_at": "2025-12-24T02:38:34.748Z"
+  }
+},
+{
+  "model": "challenges.moathonlike",
+  "pk": 123,
+  "fields": {
+    "user": 17,
+    "moathon": 2,
+    "created_at": "2025-12-24T02:38:34.749Z"
+  }
+},
+{
+  "model": "challenges.moathonlike",
+  "pk": 124,
+  "fields": {
+    "user": 26,
+    "moathon": 2,
+    "created_at": "2025-12-24T02:38:34.750Z"
+  }
+},
+{
+  "model": "challenges.moathonlike",
+  "pk": 125,
+  "fields": {
+    "user": 20,
+    "moathon": 2,
+    "created_at": "2025-12-24T02:38:34.750Z"
+  }
+},
+{
+  "model": "challenges.moathonlike",
+  "pk": 126,
+  "fields": {
+    "user": 30,
+    "moathon": 2,
+    "created_at": "2025-12-24T02:38:34.751Z"
+  }
+},
+{
+  "model": "challenges.moathonlike",
+  "pk": 127,
+  "fields": {
+    "user": 14,
+    "moathon": 2,
+    "created_at": "2025-12-24T02:38:34.752Z"
+  }
+},
+{
+  "model": "challenges.moathonlike",
+  "pk": 128,
+  "fields": {
+    "user": 15,
+    "moathon": 2,
+    "created_at": "2025-12-24T02:38:34.753Z"
+  }
+},
+{
+  "model": "challenges.moathonlike",
+  "pk": 129,
+  "fields": {
+    "user": 12,
+    "moathon": 2,
+    "created_at": "2025-12-24T02:38:34.754Z"
+  }
+},
+{
+  "model": "challenges.moathonlike",
+  "pk": 130,
+  "fields": {
+    "user": 23,
+    "moathon": 2,
+    "created_at": "2025-12-24T02:38:34.755Z"
+  }
+},
+{
+  "model": "challenges.moathonlike",
+  "pk": 131,
+  "fields": {
+    "user": 27,
+    "moathon": 2,
+    "created_at": "2025-12-24T02:38:34.755Z"
+  }
+},
+{
+  "model": "challenges.moathonlike",
+  "pk": 132,
+  "fields": {
+    "user": 25,
+    "moathon": 2,
+    "created_at": "2025-12-24T02:38:34.756Z"
+  }
+},
+{
+  "model": "challenges.moathonlike",
+  "pk": 133,
+  "fields": {
+    "user": 21,
+    "moathon": 2,
+    "created_at": "2025-12-24T02:38:34.757Z"
+  }
+},
+{
+  "model": "challenges.moathonlike",
+  "pk": 134,
+  "fields": {
+    "user": 3,
+    "moathon": 2,
+    "created_at": "2025-12-24T02:38:34.758Z"
+  }
+},
+{
+  "model": "challenges.moathonlike",
+  "pk": 135,
+  "fields": {
+    "user": 10,
+    "moathon": 2,
+    "created_at": "2025-12-24T02:38:34.759Z"
+  }
+},
+{
+  "model": "challenges.moathonlike",
+  "pk": 136,
+  "fields": {
+    "user": 6,
+    "moathon": 2,
+    "created_at": "2025-12-24T02:38:34.759Z"
+  }
+}
+]

--- a/backend/recommendations/services/stage2_openai.py
+++ b/backend/recommendations/services/stage2_openai.py
@@ -32,7 +32,7 @@ class Stage2Output:
     option_id: int # 최종 선택된 옵션 id
     reasons: List[str] # 선택 근거
     warnings: List[str] # 주의사항
-    used_fallback: bool # GMS 실패 시 규칙 기반 풀백 여부 
+    used_fallback: bool # GMS 실패 시 규칙 기반 풀백 여부
 
 
 DEVELOPER_MSG = "Answer in Korean. 반드시 JSON만 출력하고 다른 텍스트는 출력하지 마세요."
@@ -62,8 +62,8 @@ SYSTEM_INSTRUCTIONS = """\
 {
   "product_id": <int>,
   "option_id": <int>,
-  "reasons": [<string>, <string>, ...],   # 2~5개
-  "warnings": [<string>, ...]            # 0~4개
+  "reasons": [<string>, <string>, ...],
+  "warnings": [<string>, ...]
 }
 """
 
@@ -119,7 +119,7 @@ def shortlist_options_for_product(
     if not opts:
         return []
 
-    # 우대 금리가 존재하면 우대금리 우선, 아니면 기존 금리 
+    # 우대 금리가 존재하면 우대금리 우선, 아니면 기존 금리
     def rate2(o: Dict[str, Any]) -> float:
         v = o.get("intr_rate2")
         if v is None:
@@ -148,7 +148,7 @@ def shortlist_options_for_product(
         for o in ranked
     ]
 
-# 상품별 텍스트(우대조건/유의사항/만기 후 이자 등)를 상품 단위로 한 번만 모아서 payload에 넣음 
+# 상품별 텍스트(우대조건/유의사항/만기 후 이자 등)를 상품 단위로 한 번만 모아서 payload에 넣음
 def _build_product_texts(product_ids: List[int]) -> Dict[int, Dict[str, Any]]:
     """
     Top10 상품의 텍스트/메타를 상품 단위로 1번만 모아서 제공.
@@ -183,7 +183,7 @@ def _build_product_texts(product_ids: List[int]) -> Dict[int, Dict[str, Any]]:
         }
     return out
 
-# LLM 응답에서 JSON 객체 추출하고 파싱 
+# LLM 응답에서 JSON 객체 추출하고 파싱
 def _extract_json(text: str) -> Dict[str, Any]:
     t = (text or "").strip()
 
@@ -199,7 +199,7 @@ def _extract_json(text: str) -> Dict[str, Any]:
         raise ValueError("JSON 파싱 실패")
     return json.loads(t[l:r + 1])
 
-# GMS 호출 
+# GMS 호출
 def _gms_chat_completion_json(
     *,
     model: str,
@@ -230,7 +230,7 @@ def _gms_chat_completion_json(
     content = data["choices"][0]["message"]["content"]
     return _extract_json(content)
 
-# Stage1에서 받은 결과에서 최종 option_id 1개 확정 
+# Stage1에서 받은 결과에서 최종 option_id 1개 확정
 def pick_final_option_from_top10(
     *,
     user,
@@ -351,6 +351,6 @@ def pick_final_option_from_top10(
             product_id=int(first["product_id"]),
             option_id=int(first["option_id"]),
             reasons=["후보 옵션 중 조건 충족이 확인된 옵션을 선택했습니다."],
-            warnings=[], 
+            warnings=[],
             used_fallback=True,
         )


### PR DESCRIPTION
## 💡 개요 (Overview)
> 유저 프로필(팔로우, 뱃지)과 모아톤 조회(댓글, 좋아요, 뱃지)에서 확인할 fixture 데이터를 생성했습니다. 

## 📃 작업 내용 (Details)
- [ ] accounts/accounts_social.json 추가
- [ ] challenges/challenges_social.json 추가 
- [ ] 페이크 유저 닉네임 규칙 수정 (email @ 앞 패턴으로 생성)


## 📚 테스트 (Test)
- [ ] 로컬 환경에서 기능 테스트 완료
- [ ] 기존 기능에 영향 없는지 확인 완료