### PR TITLE
fix(FE): 로그인 후 팔로우 목록 조회 오류 수정

### DIFF
--- a/frontend/src/components/common/Navbar.vue
+++ b/frontend/src/components/common/Navbar.vue
@@ -23,7 +23,7 @@
           <RouterLink class="nav-link" :to="{ name: 'community' }">모아톤 커뮤니티</RouterLink>
           <RouterLink class="nav-link" :to="{ name: 'products' }">예·적금 조회</RouterLink>
           <RouterLink class="nav-link" :to="{ name: 'bank' }">은행 위치</RouterLink>
-          <RouterLink class="nav-link" :to="{ name: 'commodity' }">시세 확인</RouterLink>
+          <RouterLink class="nav-link" :to="{ name: 'commodity' }">금·은 시세</RouterLink>
           <RouterLink class="nav-link" :to="{ name: 'videoSearch' }">유튜브 검색</RouterLink>
         </div>
 

--- a/frontend/src/stores/accounts.js
+++ b/frontend/src/stores/accounts.js
@@ -29,22 +29,25 @@ export const useAccountStore = defineStore('account', () => {
       .catch(err => console.log(err))
   }
 
-  const logIn = function (payload) {
+  const logIn = async function (payload) { 
     const { username, email, password } = payload
 
-    axios({
-      method: 'post',
-      url: `${API_URL}/accounts/login/`,
-      data: {
-        username, email, password
-      }
-    })
-      .then(async res => {
-        console.log('로그인이 완료되었습니다.')
-        token.value = res.data.key
-        await getProfile()
+    try {
+      const res = await axios({
+        method: 'post',
+        url: `${API_URL}/accounts/login/`,
+        data: { username, email, password }
       })
-      .catch(err => console.log(err))
+      console.log('로그인 성공, 토큰 저장 중...')
+
+      const newToken = res.data.key
+      token.value = newToken
+      localStorage.setItem('token', newToken) 
+      await getProfile()
+    } catch (err) {
+      console.error('로그인 에러:', err)
+      throw err
+    }
   }
 
   const getProfile = async () => {
@@ -58,7 +61,7 @@ export const useAccountStore = defineStore('account', () => {
           Authorization: `Token ${token.value}`
         }
       })
-      
+
       user.value = response.data
       console.log('유저 정보 로드 완료:', user.value)
       return response.data
@@ -131,12 +134,12 @@ export const useAccountStore = defineStore('account', () => {
           'Content-Type': 'multipart/form-data'
         }
       })
-      
+
       console.log('프로필 수정 완료:', res.data)
-      
+
       // 수정 후 최신 정보를 다시 불러와 state 갱신 (데이터 동기화)
-      await getProfile() 
-      
+      await getProfile()
+
       return res.data
     } catch (err) {
       console.error('프로필 수정 실패:', err)
@@ -161,7 +164,7 @@ export const useAccountStore = defineStore('account', () => {
     }
   }
 
-  return { 
+  return {
     API_URL,
     token,
     user,
@@ -173,7 +176,7 @@ export const useAccountStore = defineStore('account', () => {
     updateProfile,
     editProfile,
     followUser,
-   }
+  }
 }, {
   persist: {
     paths: ['token', 'user']

--- a/frontend/src/stores/moathon.js
+++ b/frontend/src/stores/moathon.js
@@ -26,16 +26,16 @@ export const useMoathonStore = defineStore('moathon', () => {
   const clearMoathonDetail = () => {
     moathonDetail.value = null
   }
-  
+
   const fetchMoathons = async (page = 1) => {
     try {
       const response = await axios.get(`${API_URL}/moathons/`, {
         params: {
           page: page,
-          page_size: itemsPerPage 
+          page_size: itemsPerPage
         }
       })
-      
+
       const { results, count: totalCount } = response.data
 
       moathons.value = results
@@ -98,7 +98,7 @@ export const useMoathonStore = defineStore('moathon', () => {
       throw error
     }
   }
-  
+
   const updateMoathon = async (id, payload) => {
     try {
       const response = await axios({
@@ -124,7 +124,7 @@ export const useMoathonStore = defineStore('moathon', () => {
         headers: {
           Authorization: `Token ${accountStore.token}`,
         }
-      }) 
+      })
     } catch (err) {
       console.error('모아톤 삭제 실패:', err)
       throw err
@@ -134,11 +134,11 @@ export const useMoathonStore = defineStore('moathon', () => {
   const likeMoathon = async (moathonId) => {
     try {
       const response = await axios.post(
-        `${API_URL}/moathons/${moathonId}/like/`, 
-        {}, 
+        `${API_URL}/moathons/${moathonId}/like/`,
+        {},
         { headers: { Authorization: `Token ${accountStore.token}` } }
       )
-      
+
       if (moathonDetail.value && response.data) {
         if (!moathonDetail.value.likes) {
           moathonDetail.value.likes = { count: 0, is_liked: false }
@@ -150,7 +150,7 @@ export const useMoathonStore = defineStore('moathon', () => {
           moathonDetail.value.likes.count = response.data.like_count
         }
       }
-      
+
     } catch (err) {
       console.error('응원하기 실패:', err)
       if (err.response?.status === 401) {
@@ -185,14 +185,14 @@ export const useMoathonStore = defineStore('moathon', () => {
           Authorization: `Token ${accountStore.token}`,
         }
       })
-      
+
       await fetchComments(moathonId)
     } catch (error) {
       console.error('댓글 수정 실패:', error)
       throw error
     }
   }
-  
+
   const deleteComment = async (moathonId, commentId) => {
     try {
       await axios({
@@ -232,17 +232,23 @@ export const useMoathonStore = defineStore('moathon', () => {
 
   const getFollowingMoathons = async () => {
     try {
+      const token = localStorage.getItem('token')
+      if (!token) {
+        console.log('로그인 상태가 아니므로 팔로잉 목록을 불러오지 않습니다.')
+        return
+      }
+
       const res = await axios({
         method: 'get',
-        url: `${API_URL}/moathons/following/`, 
+        url: `${API_URL}/moathons/following/`,
         headers: {
-          Authorization: `Token ${accountStore.token}`
+          Authorization: `Token ${token}`
         }
       })
-      
+
       followingMoathons.value = res.data
       console.log('팔로잉 모아톤 로드 성공:', res.data)
-      
+
     } catch (err) {
       console.error('팔로잉 모아톤 로드 실패:', err)
       followingMoathons.value = []
@@ -256,29 +262,29 @@ export const useMoathonStore = defineStore('moathon', () => {
     console.log('Moathon Store 초기화 완료')
   }
 
-  return { 
-    moathons, 
+  return {
+    moathons,
     recommendationResult,
     isRecommending,
-    count, 
-    currentPage, 
+    count,
+    currentPage,
     itemsPerPage,
-    totalPages, 
-    moathonDetail, 
+    totalPages,
+    moathonDetail,
     followingMoathons,
     clearMoathonDetail,
     fetchMoathons,
-    fetchMoathonDetail, 
+    fetchMoathonDetail,
     fetchComments,
     createMoathon,
     updateMoathon,
     deleteMoathon,
     likeMoathon,
-    createComment, 
+    createComment,
     updateComment,
     deleteComment,
     recommendProduct,
     getFollowingMoathons,
     resetState,
-   }
+  }
 })

--- a/frontend/src/views/HomeView.vue
+++ b/frontend/src/views/HomeView.vue
@@ -119,24 +119,26 @@ const selectedMoathon = computed(() => {
 
 // 2. 팔로잉 모아톤 상태
 const followingMoathons = computed(() => moathonStore.followingMoathons || [])
-
-// 데이터 로드
 const fetchMoathonData = async () => {
-  if (!accountStore.isAuthenticated) return
-  // 무조건 친구 소식은 가져옴
-  await moathonStore.getFollowingMoathons()
+  if (accountStore.isAuthenticated) {
+    // 혹시 user 정보가 없으면 채우기
+    if (!accountStore.user) await accountStore.getProfile()
+    // 팔로잉 목록 가져오기
+    await moathonStore.getFollowingMoathons()
+  }
 }
 
 onMounted(async () => {
   try {
     loading.value = true
+    // 이미 로그인이 되어있는 경우 (새로고침 등) 바로 실행
     if (accountStore.isAuthenticated) {
-      await accountStore.getProfile()
+      await fetchMoathonData()
     }
-    await fetchMoathonData()
   } catch (err) {
     console.error(err)
   } finally {
+    // 로그인이 안 되어 있어도 로딩은 꺼줘야 함 (Type A 화면을 위해)
     loading.value = false
   }
 })
@@ -145,6 +147,17 @@ onMounted(async () => {
 watch(myActiveMoathons, (newVal) => {
   if (newVal && newVal.length > 0 && !selectedMoathonId.value) {
     selectedMoathonId.value = newVal[0].id
+  }
+}, { immediate: true })
+
+watch(() => accountStore.isAuthenticated, async (newValue) => {
+  if (newValue) {
+    console.log('로그인 완료 감지 -> 데이터 로드 시작')
+    if (!accountStore.user) {
+      await accountStore.getProfile()
+    }
+    // 팔로잉 데이터 등 메인 데이터 호출
+    await fetchMoathonData()
   }
 }, { immediate: true })
 </script>

--- a/frontend/src/views/auth/LoginView.vue
+++ b/frontend/src/views/auth/LoginView.vue
@@ -2,7 +2,7 @@
   <div>
     <h1>로그인 페이지</h1>
 
-    <form @submit.prevent="logIn">
+    <form @submit.prevent="handleLogin">
       <label for="username">이름: </label>
       <input type="text" id="username" v-model.trim="username" /> <br>
 
@@ -29,15 +29,33 @@
   const accountStore = useAccountStore()
   const router = useRouter()
 
-  const logIn = function () {
+  // const logIn = function () {
+  //   const payload = {
+  //     username: username.value,
+  //     email: email.value,
+  //     password: password.value,
+  //   }
+  //   accountStore.logIn(payload)
+  //   router.push({ name: 'home' })
+  // }
+
+  const handleLogin = async () => {
+  try {
     const payload = {
       username: username.value,
       email: email.value,
       password: password.value,
     }
-    accountStore.logIn(payload)
+    // 1. 로그인이 끝날 때까지 기다립니다.
+    await accountStore.logIn(payload) 
+    
+    // 2. 다 끝나면 이동합니다.
     router.push({ name: 'home' })
+    
+  } catch (err) {
+    alert('로그인에 실패했습니다.')
   }
+}
 </script>
 
 <style scoped>


### PR DESCRIPTION
## 💡 개요 (Overview)
> 로그인 직후 팔로우 목록 조회 시 발생하는 오류를 수정했습니다.

## 📃 작업 내용 (Details)
- logIn 액션 호출 앞에 await 키워드를 사용하여, 토큰 저장 및 프로필 로드가 100% 완료된 후 router.push가 실행되도록 보장.
- HomeView에서 watch를 사용하여 isAuthenticated 상태가 false → true로 변하는 순간(로그인 완료 시점)을 포착, 즉시 데이터를 호출하도록 구현.

## 🔗 관련 이슈 (Links)
- Closes #95 

## 📸 스크린샷 (Screenshots)
<img width="1315" height="1337" alt="image" src="https://github.com/user-attachments/assets/200a3fbc-2b65-423b-9f60-58a865cdc573" />
