### PR TITLE
[FEAT] 달리기 트랙 컴포넌트 생성 및 적용

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "axios": "^1.13.2",
+        "gsap": "^3.14.2",
         "pinia": "^3.0.4",
         "pinia-plugin-persistedstate": "^4.7.1",
         "vue": "^3.5.25",
@@ -55,6 +56,7 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -1638,6 +1640,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -2101,6 +2104,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/gsap": {
+      "version": "3.14.2",
+      "resolved": "https://registry.npmjs.org/gsap/-/gsap-3.14.2.tgz",
+      "integrity": "sha512-P8/mMxVLU7o4+55+1TCnQrPmgjPKnwkzkXOK1asnR9Jg2lna4tEY5qBJjMmAaOBDDZWtlRjBXjLa0w53G/uBLA==",
+      "license": "Standard 'no charge' license: https://gsap.com/standard-license."
+    },
     "node_modules/has-symbols": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
@@ -2409,6 +2418,7 @@
       "resolved": "https://registry.npmjs.org/pinia/-/pinia-3.0.4.tgz",
       "integrity": "sha512-l7pqLUFTI/+ESXn6k3nu30ZIzW5E2WZF/LaHJEpoq6ElcLD+wduZoB2kBN19du6K/4FDpPMazY2wJr+IndBtQw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vue/devtools-api": "^7.7.7"
       },
@@ -2697,6 +2707,7 @@
       "integrity": "sha512-ITcnkFeR3+fI8P1wMgItjGrR10170d8auB4EpMLPqmx6uxElH3a/hHGQabSHKdqd4FXWO1nFIp9rRn7JQ34ACQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.5.0",
@@ -2915,6 +2926,7 @@
       "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.25.tgz",
       "integrity": "sha512-YLVdgv2K13WJ6n+kD5owehKtEXwdwXuj2TTyJMsO7pSeKw2bfRNZGjhB7YzrpbMYj5b5QsUebHpOqR3R3ziy/g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vue/compiler-dom": "3.5.25",
         "@vue/compiler-sfc": "3.5.25",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "axios": "^1.13.2",
+    "gsap": "^3.14.2",
     "pinia": "^3.0.4",
     "pinia-plugin-persistedstate": "^4.7.1",
     "vue": "^3.5.25",

--- a/frontend/src/components/moathon/MoathonTrack.vue
+++ b/frontend/src/components/moathon/MoathonTrack.vue
@@ -1,0 +1,202 @@
+<script setup>
+import { ref, onMounted, watch, nextTick } from 'vue';
+import gsap from 'gsap';
+import { MotionPathPlugin } from 'gsap/MotionPathPlugin';
+
+gsap.registerPlugin(MotionPathPlugin);
+
+const props = defineProps({
+  percent: {
+    type: Number,
+    required: true,
+    default: 0,
+    validator: (value) => value >= 0 && value <= 100
+  },
+  duration: {
+    type: Number,
+    default: 2
+  },
+  profileImage: {
+    type: String,
+    default: null
+  }
+});
+
+const trackPath = ref(null); 
+const runnerIcon = ref(null);
+const displayPercent = ref(0);
+const pathLength = ref(0); 
+
+// 굵기와 색상 설정
+const strokeWidth = 80; 
+const trackColor = "#D9534F"; 
+const trackBgColor = "#F0E4E4"; 
+
+// 트랙 경로 데이터 (600x300 캔버스, 80px 굵기 대응)
+const trackPathData = "M 150, 40 L 450, 40 A 110, 110 0 0, 1 450, 260 L 150, 260 A 110, 110 0 0, 1 150, 40 Z";
+
+const animateTrack = () => {
+  if (!pathLength.value) return; 
+
+  const targetOffset = pathLength.value - (props.percent / 100) * pathLength.value;
+
+  // 1. 트랙 라인 그리기
+  gsap.set(trackPath.value, { strokeDasharray: pathLength.value });
+  
+  gsap.fromTo(trackPath.value, 
+    { strokeDashoffset: pathLength.value }, 
+    { 
+      strokeDashoffset: targetOffset,       
+      duration: props.duration,
+      ease: "power2.out"
+    }
+  );
+
+  // 2. 러너 이동 (여기가 수정되었습니다!)
+  gsap.to(runnerIcon.value, {
+    motionPath: {
+      path: trackPath.value,
+      align: trackPath.value,
+      alignOrigin: [0.5, 0.5], 
+      end: props.percent / 100,
+      start: 0 
+    },
+    opacity: 1, // [수정됨] 이동하면서 투명도를 1로 변경하여 보이게 함
+    duration: props.duration,
+    ease: "power2.out"
+  });
+
+  // 3. 숫자 카운팅
+  gsap.to(displayPercent, {
+    value: props.percent,
+    duration: props.duration,
+    ease: "power2.out",
+    onUpdate: () => displayPercent.value = Math.round(displayPercent.value)
+  });
+};
+
+onMounted(() => {
+  nextTick(() => {
+    if (trackPath.value) {
+      pathLength.value = trackPath.value.getTotalLength();
+      setTimeout(() => {
+        animateTrack();
+      }, 100);
+    }
+  });
+});
+
+watch(() => props.percent, () => {
+  if (pathLength.value > 0) animateTrack();
+});
+</script>
+
+<template>
+  <div class="moathon-track-container">
+    <svg width="100%" height="100%" viewBox="0 0 600 300" class="track-svg" preserveAspectRatio="xMidYMid meet">
+      
+      <path
+        :d="trackPathData"
+        fill="none"
+        :stroke="trackBgColor"
+        :stroke-width="strokeWidth"
+        stroke-linecap="butt" 
+      />
+
+      <path
+        ref="trackPath"
+        :d="trackPathData"
+        fill="none"
+        :stroke="trackColor" 
+        :stroke-width="strokeWidth"
+        stroke-linecap="butt" 
+        class="progress-path"
+      />
+      
+      <path
+        :d="trackPathData"
+        fill="none"
+        stroke="rgba(255,255,255,0.3)"
+        :stroke-width="2"
+        stroke-dasharray="10, 10"
+      />
+
+      <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" class="progress-text">
+        <tspan class="percent-number">{{ displayPercent.toFixed(0) }}</tspan>
+        <tspan class="percent-symbol">%</tspan>
+      </text>
+    </svg>
+
+    <div ref="runnerIcon" class="runner-avatar">
+      <img v-if="profileImage" :src="profileImage" alt="runner" class="profile-img" />
+      <div v-else class="default-coin">$</div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.moathon-track-container {
+  position: relative;
+  width: 100%;
+  max-width: 600px; 
+  aspect-ratio: 2 / 1;
+  margin: 0 auto;
+}
+
+.track-svg {
+  width: 100%;
+  height: 100%;
+  overflow: visible; 
+}
+
+.progress-path {
+  stroke-dasharray: 2000; 
+  stroke-dashoffset: 2000;
+}
+
+.progress-text {
+  fill: #333;
+  font-family: 'Pretendard', sans-serif;
+  font-weight: 800;
+}
+.percent-number { font-size: 64px; }
+.percent-symbol { font-size: 32px; fill: #666; }
+
+/* 러너(프로필) 스타일 */
+.runner-avatar {
+  position: absolute;
+  top: 0; left: 0;
+  width: 70px;
+  height: 70px;
+  z-index: 10;
+  pointer-events: none;
+  background: white;
+  border-radius: 50%;
+  box-shadow: 0 4px 10px rgba(0,0,0,0.3);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+  border: 4px solid white;
+  
+  /* 초기 위치 보정 */
+  transform: translate(115px, 5px); 
+  opacity: 0; /* 초기에는 숨김 (GSAP가 opacity: 1로 만듦) */
+}
+
+.profile-img { width: 100%; height: 100%; object-fit: cover; }
+
+.default-coin {
+  width: 100%; height: 100%;
+  background: #FFD700;
+  border-radius: 50%;
+  display: flex; align-items: center; justify-content: center;
+  font-weight: bold; color: #B8860B; font-size: 32px;
+}
+
+@media (max-width: 576px) {
+  .percent-number { font-size: 48px; }
+  .percent-symbol { font-size: 24px; }
+  .runner-avatar { width: 50px; height: 50px; border-width: 2px; }
+}
+</style>

--- a/frontend/src/views/HomeView.vue
+++ b/frontend/src/views/HomeView.vue
@@ -11,13 +11,13 @@
       <section class="personal-section mb-5">
         
         <div v-if="hasActiveMoathon" class="dashboard-card bg-white p-4 rounded-4 shadow-sm border">
-          <div class="d-flex justify-content-between align-items-center mb-4">
+          <div class="d-flex justify-content-between align-items-center mb-4 flex-wrap gap-2">
             <div>
               <h5 class="text-muted small mb-1">MY MOATHON</h5>
               <h2 class="fw-bold m-0">나의 목표 달성 현황</h2>
             </div>
             
-            <div class="d-flex gap-2">
+            <div class="d-flex gap-2 align-items-center">
               <select 
                 v-if="myActiveMoathons.length > 1" 
                 v-model="selectedMoathonId" 
@@ -28,18 +28,35 @@
                 </option>
               </select>
               
-              <router-link :to="{ name: 'moathonCreate' }" class="btn btn-sm btn-outline-primary fw-bold">
+              <router-link :to="{ name: 'moathonCreate' }" class="btn btn-sm btn-outline-primary fw-bold text-nowrap">
                 + 추가
               </router-link>
             </div>
           </div>
 
-          <div class="main-card-wrapper">
-            <MoathonCard 
-              v-if="selectedMoathon" 
-              :moathon="selectedMoathon" 
-              :is-highlight="true" 
-            />
+          <div class="row g-4 align-items-center">
+            <div class="col-lg-7 col-md-12">
+              <div class="p-3">
+                <MoathonTrack 
+                  :percent="currentProgress" 
+                  :profile-image="userProfileImage"
+                  :duration="2.5" 
+                />
+                <p class="text-center mt-3 mb-0 text-muted fw-bold small">
+                  목표까지 힘내세요, {{ userNickname }}님! 🏃‍♂️
+                </p>
+              </div>
+            </div>
+
+            <div class="col-lg-5 col-md-12">
+              <div class="main-card-wrapper h-100">
+                <MoathonCard 
+                  v-if="selectedMoathon" 
+                  :moathon="selectedMoathon" 
+                  :is-highlight="true" 
+                />
+              </div>
+            </div>
           </div>
         </div>
 
@@ -57,7 +74,6 @@
           </div>
         </div>
       </section>
-
 
       <section class="social-section">
         <div class="d-flex align-items-center mb-4 gap-2">
@@ -98,9 +114,12 @@ import { ref, computed, onMounted, watch } from 'vue'
 import { useAccountStore } from '@/stores/accounts'
 import { useMoathonStore } from '@/stores/moathon'
 import MoathonCard from '@/components/moathon/MoathonCard.vue'
+import MoathonTrack from '@/components/moathon/MoathonTrack.vue' // [추가] 트랙 컴포넌트 임포트
+import defaultProfile from '/default-profile.png' // [추가] 기본 이미지
 
 const accountStore = useAccountStore()
 const moathonStore = useMoathonStore()
+const API_URL = import.meta.env.VITE_API_URL // [추가] 환경 변수
 
 const loading = ref(true)
 const selectedMoathonId = ref(null)
@@ -111,10 +130,27 @@ const hasActiveMoathon = computed(() => {
 })
 const myActiveMoathons = computed(() => accountStore.user?.moathons || [])
 
-// 선택된 모아톤
+// 선택된 모아톤 객체
 const selectedMoathon = computed(() => {
   if (!selectedMoathonId.value) return myActiveMoathons.value[0]
   return myActiveMoathons.value.find(m => m.id === selectedMoathonId.value) || myActiveMoathons.value[0]
+})
+
+// [추가] 현재 선택된 모아톤의 진행률 (숫자로 변환)
+const currentProgress = computed(() => {
+  if (!selectedMoathon.value) return 0
+  return parseFloat(selectedMoathon.value.progress_rate || 0)
+})
+
+// [추가] 로그인한 유저의 닉네임
+const userNickname = computed(() => accountStore.user?.nickname || '회원')
+
+// [추가] 프로필 이미지 URL 계산 로직
+const userProfileImage = computed(() => {
+  const path = accountStore.user?.profile_image
+  if (!path) return defaultProfile
+  if (path.startsWith('http')) return path
+  return `${API_URL}${path}` // 미디어 파일 경로 처리
 })
 
 // 2. 팔로잉 모아톤 상태
@@ -150,7 +186,6 @@ watch(myActiveMoathons, (newVal) => {
 </script>
 
 <style scoped>
-/* 전체 배경색을 약간 회색으로 주어 카드 섹션을 돋보이게 할 수도 있음 (선택사항) */
 .home-wrapper {
   background-color: #fcfcfc;
   min-height: 100vh;
@@ -159,9 +194,6 @@ watch(myActiveMoathons, (newVal) => {
 /* [SECTION 1] 대시보드 스타일 */
 .dashboard-card {
   transition: transform 0.2s ease-in-out;
-}
-.dashboard-card:hover {
-  border-color: #dee2e6 !important; /* hover 시 테두리 약간 진하게 */
 }
 
 /* [SECTION 1] 히어로 배너 스타일 */

--- a/frontend/src/views/moathon/MoathonDetailView.vue
+++ b/frontend/src/views/moathon/MoathonDetailView.vue
@@ -38,6 +38,10 @@
       </div>
 
       <div class="track-visual">
+        <MoathonTrack :percent="currentProgress" :profile-image="userProfileImage" />
+      </div>
+      
+      <!-- <div class="track-visual">
         <div class="track-bg">
           <div class="track-progress" :style="{ width: trackWidth }"></div>
           <div class="runner-icon" :style="{ left: trackWidth }">
@@ -49,7 +53,7 @@
           <span>START</span>
           <span>GOAL</span>
         </div>
-      </div>
+      </div> -->
 
       <div class="info-stats">
         <div class="stat-item">
@@ -132,12 +136,14 @@
 </template>
 
 <script setup>
-import { ref, computed, watch, onUnmounted } from 'vue'
+import { ref, computed, watch, onUnmounted } from 'vue' // onMounted 제거
 import { useRoute, useRouter } from 'vue-router'
 import { useMoathonStore } from '@/stores/moathon'
 import { useAccountStore } from '@/stores/accounts'
 import ProductCard from '@/components/product/ProductCard.vue'
 import BadgeLibrary from '@/components/common/BadgeLibrary.vue'
+import MoathonTrack from '@/components/moathon/MoathonTrack.vue';
+import defaultProfile from '/default-profile.png';
 
 const route = useRoute()
 const router = useRouter()
@@ -145,13 +151,15 @@ const store = useMoathonStore()
 const accountStore = useAccountStore()
 const API_URL = import.meta.env.VITE_API_URL
 
+// store의 상태를 computed로 가져옴
 const moathon = computed(() => store.moathonDetail)
 const comments = computed(() => moathon.value?.comments || [])
 const newComment = ref('')
 const editingCommentId = ref(null)
 const editCommentContent = ref('')
+const currentProgress = ref(0) // 트랙 애니메이션용 진행률
 
-// [수정] 본인 확인 로직 (user_info 접근)
+// [안전장치 추가] moathon.value가 없을 때 에러 방지 (? 사용)
 const isOwner = computed(() => {
   return moathon.value?.user_info?.nickname === accountStore.user?.nickname
 })
@@ -161,20 +169,21 @@ const isFollowing = computed(() => {
 })
 
 const getImageUrl = (path) => {
-  if (!path) {
-    return '/default-profile.png'
-  }
-  if (path.startsWith('http')) {
-    return path
-  }
-  return `${API_URL}/media${path}`
+  if (!path) return defaultProfile
+  if (path.startsWith('http')) return path
+  return `${API_URL}${path}`
 }
 
-// [수정] 좋아요 핸들러 (Store 액션 호출 후 로직은 Store에서 처리 가정)
+// 프로필 이미지 경로 계산 (에러 방지 로직 추가)
+const userProfileImage = computed(() => {
+  if (moathon.value?.user_info?.profile_image) {
+    return getImageUrl(moathon.value.user_info.profile_image)
+  }
+  return defaultProfile;
+});
+
 const handleLike = async () => {
   const moathonId = route.params.id
-
-  // 데이터 로딩 전이거나 ID가 없으면 중단
   if (!moathonId || !moathon.value) return
 
   if (!accountStore.isAuthenticated) {
@@ -194,18 +203,19 @@ const handleFollow = async () => {
     return
   }
 
+  // moathon.value가 로드되었는지 확인
+  if (!moathon.value || !moathon.value.user_info) return;
+
   const targetUser = moathon.value.user_info
   const result = await accountStore.followUser(targetUser.id)
 
   if (result) {
-    moathon.value.user_info.is_following = result.followed
-    moathon.value.user_info.follower_count = result.follower_count
+    // [수정] 존재하지 않는 함수 fetchMoathonData() 제거 -> 스토어 액션 사용
+    await store.fetchMoathonDetail(moathon.value.id)
     await accountStore.getProfile()
-    await fetchMoathonData()
   }
 }
 
-// mappedProduct 등 나머지 로직은 기존 구조(product_option)가 유지되므로 동일
 const mappedProduct = computed(() => {
   if (!moathon.value?.product_option) return null
   const opt = moathon.value.product_option
@@ -219,7 +229,7 @@ const mappedProduct = computed(() => {
   }
 })
 
-// --- Methods (기존과 동일) ---
+// --- Methods ---
 const trackWidth = computed(() => {
   const rate = parseFloat(moathon.value?.progress_rate || 0)
   return `${Math.min(rate, 100)}%`
@@ -271,7 +281,6 @@ const saveComment = async (commentId) => {
     alert('내용을 입력해주세요.')
     return
   }
-
   try {
     const moathonId = route.params.id
     if (!moathonId) return
@@ -287,13 +296,11 @@ const submitComment = async () => {
   if (!newComment.value.trim()) return
   await store.createComment(moathon.value.id, newComment.value)
   newComment.value = ''
-  store.fetchMoathonDetail(moathon.value.id)
 }
 
 const deleteComment = async (commentId) => {
   if (confirm('댓글을 삭제하시겠습니까?')) {
     await store.deleteComment(moathon.value.id, commentId)
-    store.fetchMoathonDetail(moathon.value.id)
   }
 }
 
@@ -303,7 +310,6 @@ const handleEdit = () => {
 
 const handleDelete = async () => {
   if (!confirm('정말로 모아톤을 삭제하시겠습니까? 복구할 수 없습니다.')) return
-
   try {
     await store.deleteMoathon(moathon.value.id)
     await accountStore.getProfile()
@@ -315,13 +321,26 @@ const handleDelete = async () => {
   }
 }
 
-// 데이터 로딩
+// [핵심 수정] 데이터 로딩 로직 개선
 watch(
   () => route.params.id,
-  (newId) => {
+  async (newId) => {
     if (newId) {
       store.clearMoathonDetail()
-      store.fetchMoathonDetail(newId)
+      await store.fetchMoathonDetail(newId)
+    }
+  },
+  { immediate: true }
+)
+
+// [핵심 수정] onMounted 대신 watch로 데이터가 로드되면 progress 업데이트
+// moathon 데이터가 변경될 때마다 실행되어 로딩 직후 값을 세팅함
+watch(
+  moathon,
+  (newData) => {
+    if (newData && newData.progress_rate) {
+      // 데이터가 로드된 후 값 설정
+      currentProgress.value = newData.progress_rate
     }
   },
   { immediate: true }


### PR DESCRIPTION
## 💡 개요 (Overview)
모아톤의 진행률을 달리기 트랙 모양으로 시각화합니다.

## 📃 작업 내용 (Details)
### 시각화 컴포넌트 구현 (`MoathonTrack.vue`)
- **GSAP 라이브러리 도입**: 복잡한 애니메이션 구현을 위해 `gsap` 및 `MotionPathPlugin`을 설치하고 적용했습니다.
- **SVG 트랙 드로잉**: 타원형 육상 경기장 모양의 SVG 경로(`path`)를 생성하고, `stroke-dashoffset` 기법을 활용하여 진행률만큼 트랙이 그려지는 애니메이션을 구현했습니다.
- **프로필 러너(Runner)**: 사용자의 프로필 이미지가 트랙 경로를 따라 현재 진행률 위치까지 달리는 모션을 구현했습니다.
- **반응형 디자인**: `aspect-ratio`를 활용하여 모바일과 데스크톱 환경 모두에서 트랙 비율이 유지되도록 설정했습니다.
### 메인 페이지 대시보드 개선 (`HomeView.vue`)
- **레이아웃 변경**: 기존 카드 형태의 UI를 개선하여, 좌측에는 트랙 시각화, 우측에는 상세 정보를 배치하는 2단 그리드(`rowcol`) 구조로 변경했습니다.
- **데이터 연동**: `Pinia Store`의 데이터를 가공하여 트랙 컴포넌트에 실시간 진행률(`percent`)과 프로필 이미지(`profileImage`)를 전달했습니다.

### 상세 페이지 로직 개선 (`MoathonDetailView.vue`)
- **비동기 데이터 처리 수정**: 데이터 로딩 시점 차이로 인해 발생하던 `undefined` 에러를 해결하기 위해 `onMounted` 대신 `watch`를 사용하여 데이터 로드 후 애니메이션이 실행되도록 수정했습니다.
- **프로필 이미지 예외 처리**: 이미지가 없는 유저를 위한 기본 이미지(`default-profile.png`) 처리 로직을 추가했습니다.


## 🔗 관련 이슈 (Links)
- Closes #48 

## 📸 스크린샷 (Screenshots)
<img width="1411" height="865" alt="image" src="https://github.com/user-attachments/assets/5c13ddbe-c994-47b2-92dc-38db0c601c0c" />

## 📚 테스트 (Test)
- [x] 빌드 및 런타임 에러가 없는지 확인했습니다.
- [x] GSAP 라이브러리가 package.json에 추가되었는지 확인했습니다.
- [x] 프로필 이미지가 없는 경우 기본 아이콘이 나오는지 확인했습니다.