### PR TITLE
[REFACTOR] 댓글 컴포넌트 분리 및 팔로잉 모아톤 토큰 수정

### DIFF
--- a/frontend/src/components/moathon/CommentSection.vue
+++ b/frontend/src/components/moathon/CommentSection.vue
@@ -1,0 +1,138 @@
+<template>
+  <section class="comment-section mt-5 pt-5 border-top">
+    <h3 class="fw-bold mb-4">응원 댓글 <span class="text-primary">{{ comments.length }}</span></h3>
+
+    <div class="comment-input-wrapper mb-5">
+      <div class="input-group input-group-lg shadow-sm">
+        <input 
+          v-model="newComment" 
+          type="text" 
+          class="form-control border-0 bg-light"
+          placeholder="따뜻한 응원의 한마디를 남겨주세요! (Enter로 등록)" 
+          @keyup.enter="submitComment" 
+        />
+        <button 
+          class="btn btn-primary px-4 fw-bold" 
+          @click="submitComment" 
+          :disabled="!newComment.trim()"
+        >
+          등록
+        </button>
+      </div>
+    </div>
+
+    <div class="comment-list d-flex flex-column gap-3">
+      <div v-for="comment in comments" :key="comment.id" class="comment-item p-4 bg-white border rounded-3">
+
+        <div v-if="editingCommentId === comment.id" class="edit-mode d-flex gap-2">
+          <input 
+            v-model="editCommentContent" 
+            type="text" 
+            class="form-control"
+            @keyup.enter="saveComment(comment.id)" 
+          />
+          <button @click="saveComment(comment.id)" class="btn btn-dark text-nowrap">저장</button>
+          <button @click="cancelEdit" class="btn btn-light border text-nowrap">취소</button>
+        </div>
+
+        <div v-else>
+          <div class="d-flex justify-content-between mb-2">
+            <div class="d-flex align-items-center gap-2">
+              <span class="fw-bold">{{ comment.nickname }}</span>
+              <span class="text-muted small">{{ formatDate(comment.created_at) }}</span>
+            </div>
+            <div class="comment-actions" v-if="comment.is_owner">
+              <button 
+                @click="startEdit(comment)"
+                class="btn btn-link p-0 text-muted small text-decoration-none me-2"
+              >
+                수정
+              </button>
+              <button 
+                @click="deleteComment(comment.id)"
+                class="btn btn-link p-0 text-muted small text-decoration-none"
+              >
+                삭제
+              </button>
+            </div>
+          </div>
+          <p class="mb-0 text-dark" style="white-space: pre-wrap;">{{ comment.content }}</p>
+        </div>
+      </div>
+    </div>
+  </section>
+</template>
+
+<script setup>
+import { ref } from 'vue'
+import { useMoathonStore } from '@/stores/moathon'
+
+const props = defineProps({
+  moathonId: {
+    type: Number,
+    required: true
+  },
+  comments: {
+    type: Array,
+    default: () => []
+  }
+})
+
+const store = useMoathonStore()
+
+// Local State
+const newComment = ref('')
+const editingCommentId = ref(null)
+const editCommentContent = ref('')
+
+// Helpers
+const formatDate = (dateStr) => dateStr ? dateStr.substring(0, 10) : ''
+
+// Actions
+const submitComment = async () => {
+  if (!newComment.value.trim()) return
+  await store.createComment(props.moathonId, newComment.value)
+  newComment.value = ''
+}
+
+const startEdit = (c) => { 
+  editingCommentId.value = c.id
+  editCommentContent.value = c.content 
+}
+
+const cancelEdit = () => { 
+  editingCommentId.value = null
+  editCommentContent.value = '' 
+}
+
+const saveComment = async (commentId) => {
+  if (!editCommentContent.value.trim()) {
+    alert('내용을 입력해주세요.')
+    return
+  }
+  await store.updateComment(props.moathonId, commentId, editCommentContent.value)
+  cancelEdit()
+}
+
+const deleteComment = async (commentId) => {
+  if (confirm('댓글을 삭제하시겠습니까?')) {
+    await store.deleteComment(props.moathonId, commentId)
+  }
+}
+</script>
+
+<style scoped>
+/* 댓글 관련 CSS만 이동 */
+.comment-section h3 {
+  font-size: 1.1rem;
+}
+
+.comment-input-wrapper input:focus {
+  box-shadow: none;
+  background-color: #fff !important;
+}
+
+.comment-item {
+  transition: background-color 0.2s;
+}
+</style>

--- a/frontend/src/stores/moathon.js
+++ b/frontend/src/stores/moathon.js
@@ -232,7 +232,7 @@ export const useMoathonStore = defineStore('moathon', () => {
 
   const getFollowingMoathons = async () => {
     try {
-      const token = localStorage.getItem('token')
+      const token = accountStore.token
       if (!token) {
         console.log('로그인 상태가 아니므로 팔로잉 목록을 불러오지 않습니다.')
         return

--- a/frontend/src/views/moathon/MoathonDetailView.vue
+++ b/frontend/src/views/moathon/MoathonDetailView.vue
@@ -15,34 +15,6 @@
     </header>
 
     <div class="row g-5">
-      <div class="col-lg-4">
-        <div class="sticky-top" style="top: 2rem; z-index: 10;">
-          <div class="user-profile-card shadow-sm border">
-            <div class="profile-header d-flex flex-column align-items-center text-center pb-4 border-bottom">
-              <img :src="getImageUrl(moathon.user_info.profile_image)" class="profile-img-lg mb-3" alt="프로필" />
-              <h4 class="nickname fw-bold mb-1">{{ moathon.user_info.nickname }}</h4>
-
-              <div class="mt-3">
-                <span v-if="isOwner" class="badge bg-secondary rounded-pill px-3 py-2">나의 모아톤</span>
-                <button v-else @click="handleFollow" :class="['btn-follow', { 'following': isFollowing }]">
-                  {{ isFollowing ? '팔로잉' : '팔로우' }}
-                </button>
-              </div>
-
-              <div class="user-metrics mt-3 d-flex gap-3 text-secondary small">
-                <span>팔로워 <b class="text-dark">{{ moathon.user_info.follower_count }}</b></span>
-                <span>팔로잉 <b class="text-dark">{{ moathon.user_info.following_count }}</b></span>
-              </div>
-            </div>
-
-            <div class="badges-section pt-4">
-              <BadgeLibrary v-if="moathon.user_info.owner_badges" :badges="moathon.user_info.owner_badges" />
-              <p v-else class="text-muted small text-center py-3">아직 획득한 뱃지가 없습니다.</p>
-            </div>
-          </div>
-        </div>
-      </div>
-
       <div class="col-lg-8">
         <section class="track-section mb-5 p-4">
           <div class="track-wrapper">
@@ -66,7 +38,7 @@
         </section>
 
         <section class="product-section mb-5" v-if="mappedProduct">
-          <h5 class="fw-bold mb-3">사용 중인 금융 상품</h5>
+          <h5 class="fw-bold mb-3">사용 중인 금융 상품 🏦</h5>
           <ProductCard :product="mappedProduct" @click="goProductDetail" />
         </section>
 
@@ -79,52 +51,44 @@
             <span class="like-badge ms-2">{{ moathon.likes.count || 0 }}</span>
           </button>
         </section>
-
+        
         <hr class="d-lg-none my-5">
+      </div>
+
+      <div class="col-lg-4">
+        <div class="sticky-top" style="top: 2rem; z-index: 10;">
+          <div class="user-profile-card shadow-sm border">
+            <div class="profile-header d-flex flex-column align-items-center text-center pb-4 border-bottom">
+              <img :src="getImageUrl(moathon.user_info.profile_image)" class="profile-img-lg mb-3" alt="프로필" />
+              <h4 class="nickname fw-bold mb-1">{{ moathon.user_info.nickname }}</h4>
+
+              <div class="mt-3">
+                <span v-if="isOwner" class="badge bg-secondary rounded-pill px-3 py-2">나의 모아톤</span>
+                <button v-else @click="handleFollow" :class="['btn-follow', { 'following': isFollowing }]">
+                  {{ isFollowing ? '팔로잉' : '팔로우' }}
+                </button>
+              </div>
+
+              <div class="user-metrics mt-3 d-flex gap-3 text-secondary small">
+                <span>팔로워 <b class="text-dark">{{ moathon.user_info.follower_count }}</b></span>
+                <span>팔로잉 <b class="text-dark">{{ moathon.user_info.following_count }}</b></span>
+              </div>
+            </div>
+
+            <div class="badges-section pt-4">
+              <h6 class="fw-bold text-start mb-3 ms-2">획득한 뱃지</h6>
+              <BadgeLibrary v-if="moathon.user_info.owner_badges" :badges="moathon.user_info.owner_badges" />
+              <p v-else class="text-muted small text-center py-3">아직 획득한 뱃지가 없습니다.</p>
+            </div>
+          </div>
+        </div>
       </div>
     </div>
 
-    <section class="comment-section mt-5 pt-5 border-top">
-      <h3 class="fw-bold mb-4">응원 댓글 <span class="text-primary">{{ comments.length }}</span></h3>
-
-      <div class="comment-input-wrapper mb-5">
-        <div class="input-group input-group-lg shadow-sm">
-          <input v-model="newComment" type="text" class="form-control border-0 bg-light"
-            placeholder="따뜻한 응원의 한마디를 남겨주세요! (Enter로 등록)" @keyup.enter="submitComment" />
-          <button class="btn btn-primary px-4 fw-bold" @click="submitComment" :disabled="!newComment.trim()">
-            등록
-          </button>
-        </div>
-      </div>
-
-      <div class="comment-list d-flex flex-column gap-3">
-        <div v-for="comment in comments" :key="comment.id" class="comment-item p-4 bg-white border rounded-3">
-
-          <div v-if="editingCommentId === comment.id" class="edit-mode d-flex gap-2">
-            <input v-model="editCommentContent" type="text" class="form-control"
-              @keyup.enter="saveComment(comment.id)" />
-            <button @click="saveComment(comment.id)" class="btn btn-dark text-nowrap">저장</button>
-            <button @click="cancelEdit" class="btn btn-light border text-nowrap">취소</button>
-          </div>
-
-          <div v-else>
-            <div class="d-flex justify-content-between mb-2">
-              <div class="d-flex align-items-center gap-2">
-                <span class="fw-bold">{{ comment.nickname }}</span>
-                <span class="text-muted small">{{ formatDate(comment.created_at) }}</span>
-              </div>
-              <div class="comment-actions" v-if="comment.is_owner">
-                <button @click="startEdit(comment)"
-                  class="btn btn-link p-0 text-muted small text-decoration-none me-2">수정</button>
-                <button @click="deleteComment(comment.id)"
-                  class="btn btn-link p-0 text-muted small text-decoration-none">삭제</button>
-              </div>
-            </div>
-            <p class="mb-0 text-dark" style="white-space: pre-wrap;">{{ comment.content }}</p>
-          </div>
-        </div>
-      </div>
-    </section>
+    <CommentSection 
+      :moathon-id="moathon.id" 
+      :comments="comments" 
+    />
 
   </div>
   <div v-else class="loading-container d-flex justify-content-center align-items-center vh-100">
@@ -142,7 +106,8 @@ import { useAccountStore } from '@/stores/accounts'
 import ProductCard from '@/components/product/ProductCard.vue'
 import BadgeLibrary from '@/components/common/BadgeLibrary.vue'
 import MoathonTrack from '@/components/moathon/MoathonTrack.vue';
-import defaultProfile from '/default-profile.png'; // [수정] 경로 수정
+import CommentSection from '@/components/moathon/CommentSection.vue';
+import defaultProfile from '/default-profile.png';
 
 const route = useRoute()
 const router = useRouter()
@@ -152,9 +117,6 @@ const API_URL = import.meta.env.VITE_API_URL
 
 const moathon = computed(() => store.moathonDetail)
 const comments = computed(() => moathon.value?.comments || [])
-const newComment = ref('')
-const editingCommentId = ref(null)
-const editCommentContent = ref('')
 const currentProgress = ref(0)
 
 const isOwner = computed(() => moathon.value?.user_info?.nickname === accountStore.user?.nickname)
@@ -219,29 +181,13 @@ const formatPurpose = (code) => {
   const map = { 'GOAL': '목돈 만들기', 'SHORT': '단기 여유자금', 'SAFE': '안정적 자산 보관', 'YIELD': '이자 극대화', 'HABIT': '저축 습관 형성' }
   return map[code] || code
 }
-const formatDate = (dateStr) => dateStr ? dateStr.substring(0, 10) : ''
 
 const goProductDetail = () => {
   if (mappedProduct.value?.id) router.push({ name: 'productDetail', params: { id: mappedProduct.value.id } })
 }
 
-// --- Comment Actions ---
-const startEdit = (c) => { editingCommentId.value = c.id; editCommentContent.value = c.content }
-const cancelEdit = () => { editingCommentId.value = null; editCommentContent.value = '' }
-const submitComment = async () => {
-  if (!newComment.value.trim()) return
-  await store.createComment(moathon.value.id, newComment.value)
-  newComment.value = ''
-}
-const saveComment = async (cid) => {
-  if (!editCommentContent.value.trim()) return alert('내용 입력')
-  await store.updateComment(route.params.id, cid, editCommentContent.value)
-  cancelEdit()
-}
-const deleteComment = async (cid) => {
-  if (confirm('삭제하시겠습니까?')) await store.deleteComment(moathon.value.id, cid)
-}
 const handleEdit = () => router.push({ name: 'moathonUpdate', params: { id: moathon.value.id } })
+
 const handleDelete = async () => {
   if (confirm('정말 삭제하시겠습니까?')) {
     await store.deleteMoathon(moathon.value.id)
@@ -265,143 +211,54 @@ onUnmounted(() => store.clearMoathonDetail())
 </script>
 
 <style scoped>
-/* 타이틀 & 뱃지 */
+/* 페이지 전체에 영향을 주는 주요 스타일만 남김 */
 .badge-purpose {
-  background-color: #e3f2fd;
-  color: #0d6efd;
-  padding: 6px 12px;
-  border-radius: 8px;
-  font-size: 0.9rem;
-  font-weight: 700;
+  background-color: #e3f2fd; color: #0d6efd; 
+  padding: 6px 12px; border-radius: 8px; font-size: 0.9rem; font-weight: 700;
 }
+.moathon-title { color: #333; margin-top: 0.5rem; }
 
-.moathon-title {
-  color: #333;
-  margin-top: 0.5rem;
-}
-
-/* 정보 그리드 (Stats) */
 .info-stats-grid {
-  display: grid;
-  grid-template-columns: repeat(3, 1fr);
-  gap: 20px;
+  display: grid; grid-template-columns: repeat(3, 1fr); gap: 20px;
 }
-
 .stat-card {
-  background: #fff;
-  border: 1px solid #eee;
-  border-radius: 16px;
-  padding: 20px;
-  text-align: center;
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.02);
+  background: #fff; border: 1px solid #eee; border-radius: 16px;
+  padding: 20px; text-align: center;
+  display: flex; flex-direction: column; gap: 8px;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.02);
 }
+.stat-card .label { font-size: 0.85rem; color: #888; font-weight: 600; }
+.stat-card .value { font-size: 1.1rem; font-weight: 800; color: #333; }
 
-.stat-card .label {
-  font-size: 0.85rem;
-  color: #888;
-  font-weight: 600;
-}
-
-.stat-card .value {
-  font-size: 1.1rem;
-  font-weight: 800;
-  color: #333;
-}
-
-/* 좋아요 버튼 (Large) */
 .btn-like-large {
-  width: 100%;
-  padding: 18px;
-  background: white;
-  border: 2px solid #eee;
-  border-radius: 16px;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  transition: all 0.2s ease;
-  cursor: pointer;
+  width: 100%; padding: 18px;
+  background: white; border: 2px solid #eee; border-radius: 16px;
+  display: flex; justify-content: center; align-items: center;
+  transition: all 0.2s ease; cursor: pointer;
 }
+.btn-like-large:hover { background: #f8f9fa; border-color: #ddd; }
+.btn-like-large.active { background: #fff0f3; border-color: #ffc9db; color: #e0245e; }
+.like-badge { background: #f1f3f5; padding: 2px 10px; border-radius: 20px; font-weight: bold; font-size: 0.9rem; }
+.btn-like-large.active .like-badge { background: #ffe3e8; color: #e0245e; }
 
-.btn-like-large:hover {
-  background: #f8f9fa;
-  border-color: #ddd;
-}
-
-.btn-like-large.active {
-  background: #fff0f3;
-  border-color: #ffc9db;
-  color: #e0245e;
-}
-
-.like-badge {
-  background: #f1f3f5;
-  padding: 2px 10px;
-  border-radius: 20px;
-  font-weight: bold;
-  font-size: 0.9rem;
-}
-
-.btn-like-large.active .like-badge {
-  background: #ffe3e8;
-  color: #e0245e;
-}
-
-/* 우측 프로필 카드 */
 .user-profile-card {
-  background: #fff;
-  border-radius: 20px;
-  padding: 30px 20px;
+  background: #fff; border-radius: 20px; padding: 30px 20px;
 }
-
 .profile-img-lg {
-  width: 100px;
-  height: 100px;
-  border-radius: 50%;
-  object-fit: cover;
-  border: 4px solid #f8f9fa;
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
+  width: 100px; height: 100px; border-radius: 50%;
+  object-fit: cover; border: 4px solid #f8f9fa;
+  box-shadow: 0 4px 12px rgba(0,0,0,0.08);
 }
-
 .btn-follow {
-  padding: 8px 24px;
-  border-radius: 50px;
-  border: none;
-  font-weight: bold;
-  background: #0d6efd;
-  color: white;
-  transition: all 0.2s;
+  padding: 8px 24px; border-radius: 50px; border: none; font-weight: bold;
+  background: #0d6efd; color: white; transition: all 0.2s;
 }
+.btn-follow:hover { background: #0b5ed7; }
+.btn-follow.following { background: #e9ecef; color: #495057; border: 1px solid #ced4da; }
+.btn-follow.following:hover { color: #dc3545; background: #ffeea1; border-color: #ffeea1; }
 
-.btn-follow:hover {
-  background: #0b5ed7;
-}
-
-.btn-follow.following {
-  background: #e9ecef;
-  color: #495057;
-  border: 1px solid #ced4da;
-}
-
-.btn-follow.following:hover {
-  color: #dc3545;
-  background: #ffeea1;
-  border-color: #ffeea1;
-}
-
-/* 반응형 모바일 대응 */
 @media (max-width: 991px) {
-  .info-stats-grid {
-    grid-template-columns: 1fr;
-  }
-
-  /* 모바일에서 통계 세로 정렬 */
-  .sticky-top {
-    position: static !important;
-  }
-
-  /* 모바일에서 sticky 해제 */
+  .info-stats-grid { grid-template-columns: 1fr; }
+  .sticky-top { position: static !important; }
 }
 </style>


### PR DESCRIPTION
## 💡 개요 (Overview)
팔로우 후에 메인페이지로 돌아갔을 때, 팔로잉 모아톤 목록이 보이지 않는 문제를 해결했습니다.

## 📃 작업 내용 (Details)
- [ ] getFollowingMoathons 액션 내 token = accountStore.token 값으로 변경함
- [ ] 모아톤 상세 페이지 내부 댓글 섹션을 컴포넌트로 분리함

## 📸 스크린샷 (Screenshots)
<img width="1911" height="859" alt="image" src="https://github.com/user-attachments/assets/cdf2c61c-9d31-48e5-8280-025451d8e375" />


## 📚 테스트 (Test)
- [ ] 로컬 환경에서 기능 테스트 완료
- [ ] 기존 기능에 영향 없는지 확인 완료