### PR TITLE
[FIX] 권한 설정 변경 및 비로그인 사용자 접근 UX 개선

### DIFF
--- a/backend/accounts/views.py
+++ b/backend/accounts/views.py
@@ -304,7 +304,6 @@ def onboarding(request):
 
 @extend_schema(summary="뱃지 컬렉션 조회")
 @api_view(['GET'])
-@permission_classes([IsAuthenticated])
 def badge_collection(request):
     user = request.user
 

--- a/backend/moathon/settings.py
+++ b/backend/moathon/settings.py
@@ -79,7 +79,7 @@ REST_FRAMEWORK = {
         'rest_framework.authentication.SessionAuthentication', # 개발자 테스트용 (Swagger)
     ],
     'DEFAULT_PERMISSION_CLASSES': [
-        'rest_framework.permissions.AllowAny',
+        'rest_framework.permissions.IsAuthenticatedOrReadOnly',
     ],
     'DEFAULT_SCHEMA_CLASS': 'drf_spectacular.openapi.AutoSchema',
 }

--- a/frontend/src/stores/moathon.js
+++ b/frontend/src/stores/moathon.js
@@ -29,12 +29,21 @@ export const useMoathonStore = defineStore('moathon', () => {
 
   const fetchMoathons = async (page = 1) => {
     try {
-      const response = await axios.get(`${API_URL}/moathons/`, {
-        params: {
-          page: page,
-          page_size: itemsPerPage
-        }
-      })
+      const config = {
+         method: 'get',
+         url: `${API_URL}/moathons/`,
+         params: {
+           page: page,
+           page_size: itemsPerPage 
+         },
+         headers: {}
+      }
+      
+      if (accountStore.token) {
+        config.headers.Authorization = `Token ${accountStore.token}`
+      }
+      
+      const response = await axios(config)
 
       const { results, count: totalCount } = response.data
 
@@ -49,28 +58,37 @@ export const useMoathonStore = defineStore('moathon', () => {
 
   const fetchMoathonDetail = async (id) => {
     try {
-      const response = await axios({
+      const config = {
         method: 'get',
         url: `${API_URL}/moathons/${id}/`,
-        headers: {
-          Authorization: `Token ${accountStore.token}`,
-        }
-      })
+        headers: {}
+      }
+
+      if (accountStore.token) {
+        config.headers.Authorization = `Token ${accountStore.token}`
+      }
+
+      const response = await axios(config)
       moathonDetail.value = response.data
     } catch (error) {
       console.error('모아톤 상세 조회 실패:', error)
+      throw error
     }
   }
 
   const fetchComments = async (moathonId) => {
     try {
-      const response = await axios({
+      const config = {
         method: 'get',
         url: `${API_URL}/moathons/${moathonId}/comments/`,
-        headers: {
-          Authorization: `Token ${accountStore.token}`,
-        }
-      })
+        headers: {}
+      }
+
+      if (accountStore.token) {
+        config.headers.Authorization = `Token ${accountStore.token}`
+      }
+
+      const response = await axios(config)
       const commentList = response.data.results ? response.data.results : response.data
 
       if (moathonDetail.value) {

--- a/frontend/src/stores/products.js
+++ b/frontend/src/stores/products.js
@@ -40,13 +40,11 @@ export const useProductStore = defineStore('product', () => {
       const response = await axios({
         method: 'get',
         url: `${API_URL}/products/${id}/`,
-        headers: {
-          Authorization: `Token ${accountStore.token}`,
-        },
       })
       productDetail.value = response.data
     } catch (error) {
       console.error('상품 상세 조회 실패:', error)
+      throw error
     }
   }
 
@@ -54,7 +52,7 @@ export const useProductStore = defineStore('product', () => {
     if (banks.value.length > 0) return
 
     try {
-      const response = await axios ({
+      const response = await axios({
         method: 'get',
         url: `${API_URL}/products/banklist/`,
       })

--- a/frontend/src/views/HomeView.vue
+++ b/frontend/src/views/HomeView.vue
@@ -68,9 +68,13 @@
               나에게 딱 맞는 예적금 상품을 추천받고<br>
               친구들과 함께 저축 챌린지를 시작해보세요.
             </p>
-            <router-link :to="{ name: 'moathonCreate' }" class="btn btn-primary px-5 py-3 fw-bold shadow-sm rounded-pill">
+            <a 
+              href="#" 
+              @click.prevent="handleStartRecommendation" 
+              class="btn btn-primary px-5 py-3 fw-bold shadow-sm rounded-pill"
+            >
               내 맞춤 모아톤 만들기
-            </router-link>
+            </a>
           </div>
         </div>
       </section>
@@ -111,75 +115,94 @@
 
 <script setup>
 import { ref, computed, onMounted, watch } from 'vue'
+import { useRouter, useRoute } from 'vue-router'
 import { useAccountStore } from '@/stores/accounts'
 import { useMoathonStore } from '@/stores/moathon'
 import MoathonCard from '@/components/moathon/MoathonCard.vue'
-import MoathonTrack from '@/components/moathon/MoathonTrack.vue' // [추가] 트랙 컴포넌트 임포트
-import defaultProfile from '/default-profile.png' // [추가] 기본 이미지
+import MoathonTrack from '@/components/moathon/MoathonTrack.vue'
+import defaultProfile from '/default-profile.png'
 
+const router = useRouter()
 const accountStore = useAccountStore()
 const moathonStore = useMoathonStore()
-const API_URL = import.meta.env.VITE_API_URL // [추가] 환경 변수
+const API_URL = import.meta.env.VITE_API_URL
 
 const loading = ref(true)
 const selectedMoathonId = ref(null)
 
-// 1. 내 모아톤 상태
 const hasActiveMoathon = computed(() => {
   return accountStore.user?.moathons && accountStore.user.moathons.length > 0
 })
 const myActiveMoathons = computed(() => accountStore.user?.moathons || [])
 
-// 선택된 모아톤 객체
 const selectedMoathon = computed(() => {
   if (!selectedMoathonId.value) return myActiveMoathons.value[0]
   return myActiveMoathons.value.find(m => m.id === selectedMoathonId.value) || myActiveMoathons.value[0]
 })
 
-// [추가] 현재 선택된 모아톤의 진행률 (숫자로 변환)
 const currentProgress = computed(() => {
   if (!selectedMoathon.value) return 0
   return parseFloat(selectedMoathon.value.progress_rate || 0)
 })
 
-// [추가] 로그인한 유저의 닉네임
 const userNickname = computed(() => accountStore.user?.nickname || '회원')
 
-// [추가] 프로필 이미지 URL 계산 로직
 const userProfileImage = computed(() => {
   const path = accountStore.user?.profile_image
   if (!path) return defaultProfile
   if (path.startsWith('http')) return path
-  return `${API_URL}${path}` // 미디어 파일 경로 처리
+  return `${API_URL}${path}`
 })
 
-// 2. 팔로잉 모아톤 상태
 const followingMoathons = computed(() => moathonStore.followingMoathons || [])
+
 const fetchMoathonData = async () => {
   if (accountStore.isAuthenticated) {
-    // 혹시 user 정보가 없으면 채우기
     if (!accountStore.user) await accountStore.getProfile()
-    // 팔로잉 목록 가져오기
     await moathonStore.getFollowingMoathons()
   }
+}
+
+const handleStartRecommendation = () => {
+  if (!accountStore.isAuthenticated) {
+    const userConfirm = confirm('로그인이 필요한 서비스입니다.\n로그인 페이지로 이동하시겠습니까?')
+    if (userConfirm) {
+      router.push({ name: 'login' })
+    }
+    return
+  }
+
+  const user = accountStore.user
+  const isProfileIncomplete = user?.gender === null || user?.credit_score === null || user?.assets === null || user?.salary === null || user?.average_monthly_spend === null || user?.tender === null
+  if (isProfileIncomplete) {
+    const confirmMsg = confirm(
+      '상품 추천을 위해 추가 정보가 필요합니다.\n\n프로필 수정 페이지로 이동하여 정보를 입력하시겠습니까?'
+    )
+    if (confirmMsg) {
+      router.push({ 
+        name: 'mypage',
+        query: { edit: 'true' }
+      })
+    }
+    return
+  }
+
+  router.push({ name: 'moathonRecommend' })
 }
 
 onMounted(async () => {
   try {
     loading.value = true
-    // 이미 로그인이 되어있는 경우 (새로고침 등) 바로 실행
     if (accountStore.isAuthenticated) {
       await fetchMoathonData()
     }
   } catch (err) {
     console.error(err)
   } finally {
-    // 로그인이 안 되어 있어도 로딩은 꺼줘야 함 (Type A 화면을 위해)
     loading.value = false
   }
 })
 
-// 드롭다운 기본값 설정 watcher
 watch(myActiveMoathons, (newVal) => {
   if (newVal && newVal.length > 0 && !selectedMoathonId.value) {
     selectedMoathonId.value = newVal[0].id
@@ -192,7 +215,6 @@ watch(() => accountStore.isAuthenticated, async (newValue) => {
     if (!accountStore.user) {
       await accountStore.getProfile()
     }
-    // 팔로잉 데이터 등 메인 데이터 호출
     await fetchMoathonData()
   }
 }, { immediate: true })

--- a/frontend/src/views/moathon/MoathonDetailView.vue
+++ b/frontend/src/views/moathon/MoathonDetailView.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="container py-5" v-if="moathon">
+  <div class="container py-5" v-if="!isLoading && moathon">
 
     <header class="detail-header mb-5">
       <div class="d-flex justify-content-between align-items-end border-bottom pb-3">
@@ -38,7 +38,7 @@
         </section>
 
         <section class="product-section mb-5" v-if="mappedProduct">
-          <h5 class="fw-bold mb-3">사용 중인 금융 상품 🏦</h5>
+          <h5 class="fw-bold mb-3">사용 중인 금융 상품</h5>
           <ProductCard :product="mappedProduct" @click="goProductDetail" />
         </section>
 
@@ -51,7 +51,7 @@
             <span class="like-badge ms-2">{{ moathon.likes.count || 0 }}</span>
           </button>
         </section>
-        
+
         <hr class="d-lg-none my-5">
       </div>
 
@@ -85,16 +85,20 @@
       </div>
     </div>
 
-    <CommentSection 
-      :moathon-id="moathon.id" 
-      :comments="comments" 
-    />
+    <CommentSection :moathon-id="moathon.id" :comments="comments" />
 
   </div>
-  <div v-else class="loading-container d-flex justify-content-center align-items-center vh-100">
+
+  <div v-else-if="isLoading" class="loading-container d-flex justify-content-center align-items-center vh-100">
     <div class="spinner-border text-primary" role="status">
       <span class="visually-hidden">Loading...</span>
     </div>
+  </div>
+
+  <div v-else class="error-container d-flex flex-column justify-content-center align-items-center vh-100">
+    <h3 class="text-muted mb-3">모아톤 정보를 불러올 수 없습니다.</h3>
+    <p class="text-secondary mb-4">존재하지 않거나 삭제된 페이지일 수 있습니다.</p>
+    <button @click="router.push({ name: 'home' })" class="btn btn-primary px-4">홈으로 돌아가기</button>
   </div>
 </template>
 
@@ -118,6 +122,7 @@ const API_URL = import.meta.env.VITE_API_URL
 const moathon = computed(() => store.moathonDetail)
 const comments = computed(() => moathon.value?.comments || [])
 const currentProgress = ref(0)
+const isLoading = ref(true)
 
 const isOwner = computed(() => moathon.value?.user_info?.nickname === accountStore.user?.nickname)
 const isFollowing = computed(() => moathon.value?.user_info?.is_following)
@@ -137,7 +142,9 @@ const userProfileImage = computed(() => {
 
 const handleLike = async () => {
   if (!accountStore.isAuthenticated) {
-    if (confirm('로그인이 필요한 서비스입니다. 로그인 하시겠습니까?')) router.push({ name: 'login' })
+    if (confirm('로그인이 필요한 서비스입니다. 로그인 하시겠습니까?')) {
+      router.push({ name: 'login' })
+    }
     return
   }
   await store.likeMoathon(route.params.id)
@@ -198,8 +205,26 @@ const handleDelete = async () => {
 // --- Watchers ---
 watch(() => route.params.id, async (newId) => {
   if (newId) {
+    isLoading.value = true // 로딩 시작
     store.clearMoathonDetail()
-    await store.fetchMoathonDetail(newId)
+
+    try {
+      await store.fetchMoathonDetail(newId)
+      isLoading.value = false
+    } catch (error) {
+      const status = error.response?.status
+
+      // CASE 1: 비로그인 유저 접근 (401 Unauthorized)
+      if (status === 401) {
+        alert("로그인이 필요한 서비스입니다.")
+        router.push({ name: 'login' })
+        return // 로딩 상태를 끄지 않고 페이지 이동
+      } else {
+        // [CASE 2] 기타 에러 (404 등) -> 에러 화면 표시
+        console.error("Detail Load Error:", error)
+        isLoading.value = false
+      }
+    }
   }
 }, { immediate: true })
 
@@ -211,54 +236,135 @@ onUnmounted(() => store.clearMoathonDetail())
 </script>
 
 <style scoped>
-/* 페이지 전체에 영향을 주는 주요 스타일만 남김 */
 .badge-purpose {
-  background-color: #e3f2fd; color: #0d6efd; 
-  padding: 6px 12px; border-radius: 8px; font-size: 0.9rem; font-weight: 700;
+  background-color: #e3f2fd;
+  color: #0d6efd;
+  padding: 6px 12px;
+  border-radius: 8px;
+  font-size: 0.9rem;
+  font-weight: 700;
 }
-.moathon-title { color: #333; margin-top: 0.5rem; }
+
+.moathon-title {
+  color: #333;
+  margin-top: 0.5rem;
+}
 
 .info-stats-grid {
-  display: grid; grid-template-columns: repeat(3, 1fr); gap: 20px;
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 20px;
 }
+
 .stat-card {
-  background: #fff; border: 1px solid #eee; border-radius: 16px;
-  padding: 20px; text-align: center;
-  display: flex; flex-direction: column; gap: 8px;
-  box-shadow: 0 2px 8px rgba(0,0,0,0.02);
+  background: #fff;
+  border: 1px solid #eee;
+  border-radius: 16px;
+  padding: 20px;
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.02);
 }
-.stat-card .label { font-size: 0.85rem; color: #888; font-weight: 600; }
-.stat-card .value { font-size: 1.1rem; font-weight: 800; color: #333; }
+
+.stat-card .label {
+  font-size: 0.85rem;
+  color: #888;
+  font-weight: 600;
+}
+
+.stat-card .value {
+  font-size: 1.1rem;
+  font-weight: 800;
+  color: #333;
+}
 
 .btn-like-large {
-  width: 100%; padding: 18px;
-  background: white; border: 2px solid #eee; border-radius: 16px;
-  display: flex; justify-content: center; align-items: center;
-  transition: all 0.2s ease; cursor: pointer;
+  width: 100%;
+  padding: 18px;
+  background: white;
+  border: 2px solid #eee;
+  border-radius: 16px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  transition: all 0.2s ease;
+  cursor: pointer;
 }
-.btn-like-large:hover { background: #f8f9fa; border-color: #ddd; }
-.btn-like-large.active { background: #fff0f3; border-color: #ffc9db; color: #e0245e; }
-.like-badge { background: #f1f3f5; padding: 2px 10px; border-radius: 20px; font-weight: bold; font-size: 0.9rem; }
-.btn-like-large.active .like-badge { background: #ffe3e8; color: #e0245e; }
+
+.btn-like-large:hover {
+  background: #f8f9fa;
+  border-color: #ddd;
+}
+
+.btn-like-large.active {
+  background: #fff0f3;
+  border-color: #ffc9db;
+  color: #e0245e;
+}
+
+.like-badge {
+  background: #f1f3f5;
+  padding: 2px 10px;
+  border-radius: 20px;
+  font-weight: bold;
+  font-size: 0.9rem;
+}
+
+.btn-like-large.active .like-badge {
+  background: #ffe3e8;
+  color: #e0245e;
+}
 
 .user-profile-card {
-  background: #fff; border-radius: 20px; padding: 30px 20px;
+  background: #fff;
+  border-radius: 20px;
+  padding: 30px 20px;
 }
+
 .profile-img-lg {
-  width: 100px; height: 100px; border-radius: 50%;
-  object-fit: cover; border: 4px solid #f8f9fa;
-  box-shadow: 0 4px 12px rgba(0,0,0,0.08);
+  width: 100px;
+  height: 100px;
+  border-radius: 50%;
+  object-fit: cover;
+  border: 4px solid #f8f9fa;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
 }
+
 .btn-follow {
-  padding: 8px 24px; border-radius: 50px; border: none; font-weight: bold;
-  background: #0d6efd; color: white; transition: all 0.2s;
+  padding: 8px 24px;
+  border-radius: 50px;
+  border: none;
+  font-weight: bold;
+  background: #0d6efd;
+  color: white;
+  transition: all 0.2s;
 }
-.btn-follow:hover { background: #0b5ed7; }
-.btn-follow.following { background: #e9ecef; color: #495057; border: 1px solid #ced4da; }
-.btn-follow.following:hover { color: #dc3545; background: #ffeea1; border-color: #ffeea1; }
+
+.btn-follow:hover {
+  background: #0b5ed7;
+}
+
+.btn-follow.following {
+  background: #e9ecef;
+  color: #495057;
+  border: 1px solid #ced4da;
+}
+
+.btn-follow.following:hover {
+  color: #dc3545;
+  background: #ffeea1;
+  border-color: #ffeea1;
+}
 
 @media (max-width: 991px) {
-  .info-stats-grid { grid-template-columns: 1fr; }
-  .sticky-top { position: static !important; }
+  .info-stats-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .sticky-top {
+    position: static !important;
+  }
 }
 </style>

--- a/frontend/src/views/product/ProductDetailView.vue
+++ b/frontend/src/views/product/ProductDetailView.vue
@@ -1,9 +1,12 @@
 <template>
   <div class="detail-container" v-if="product">
     <div class="product-info-section">
-      <span class="bank-badge">{{ product.kor_co_nm }}</span>
+      <span class="bank-badge">{{ product.bank_name }}</span>
+      <span class="type-badge" :class="product.product_type">
+        {{ product.product_type === 'DEPOSIT' ? '예금' : '적금' }}
+      </span>
       <h1 class="title">{{ product.fin_prdt_nm }}</h1>
-      
+
       <div class="info-grid">
         <div class="info-item">
           <h4>가입 방법</h4>
@@ -26,12 +29,9 @@
       <h2>금리 및 기간 옵션</h2>
       <p class="desc">원하는 조건을 선택하여 저축 챌린지를 시작해보세요.</p>
 
-      <ProductOptionList 
-        v-if="product.options && product.options.length > 0"
-        :options="product.options" 
-        @select-option="goMoathonCreate"
-      />
-      
+      <ProductOptionList v-if="product.options && product.options.length > 0" :options="product.options"
+        @select-option="goMoathonCreate" />
+
       <div v-else class="empty-options">
         <p>상세 옵션 정보가 없습니다.</p>
       </div>
@@ -44,50 +44,153 @@
 </template>
 
 <script setup>
-import { computed, onMounted } from 'vue'
+import { computed, watch, ref } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { useProductStore } from '@/stores/products'
+import { useAccountStore } from '@/stores/accounts'
 import ProductOptionList from '@/components/product/ProductOptionList.vue'
 
 const store = useProductStore()
+const accountStore = useAccountStore()
 const route = useRoute()
 const router = useRouter()
 
+const isLoading = ref(true)
 const product = computed(() => store.productDetail)
 
-onMounted(() => {
-  store.getProductDetail(route.params.id)
-})
+const fetchProduct = async (productId) => {
+  isLoading.value = true
+  try {
+    await store.getProductDetail(productId)
+  } catch (err) {
+    console.error('상품 정보 로딩 실패:', err)
+  } finally {
+    isLoading.value = false
+  }
+}
+
+watch(
+  () => route.params.id,
+  (newId) => {
+    if (newId) fetchProduct(newId)
+  },
+  { immediate: true }
+)
 
 const goMoathonCreate = (optionId) => {
-  router.push({ 
-    name: 'moathonCreate', 
-    query: { productId: optionId } 
+  if (!accountStore.isLogin) {
+    const userConfirm = confirm('로그인이 필요한 서비스입니다.\n로그인 페이지로 이동하시겠습니까?')
+    
+    if (userConfirm) {
+      router.push({ name: 'login' })
+    }
+    return
+  }
+
+  router.push({
+    name: 'moathonCreate',
+    query: { productId: optionId }
   })
 }
 </script>
 
 <style scoped>
-.detail-container { max-width: 800px; margin: 0 auto; padding: 40px 20px; }
-.loading { text-align: center; padding: 50px; color: #888; }
-
-/* 상품 기본 정보 스타일 유지 */
-.product-info-section { text-align: center; margin-bottom: 30px; }
-.bank-badge { background: #e3f2fd; color: #1565c0; padding: 6px 12px; border-radius: 20px; font-weight: bold; font-size: 0.9rem; }
-.title { font-size: 2rem; margin: 16px 0 30px; color: #333; }
-
-.info-grid { 
-  display: grid; grid-template-columns: 1fr 1fr; gap: 20px; 
-  background: #f8f9fa; padding: 24px; border-radius: 16px; text-align: left; 
+.detail-container {
+  max-width: 1000px;
+  margin: 0 auto;
+  padding: 40px 20px;
 }
-.info-item h4 { font-size: 0.9rem; color: #666; margin-bottom: 8px; }
-.info-item p { font-size: 1rem; color: #333; line-height: 1.5; }
-.full-width { grid-column: 1 / -1; }
 
-.divider { border: 0; height: 1px; background: #eee; margin: 40px 0; }
+.loading {
+  text-align: center;
+  padding: 50px;
+  color: #888;
+}
 
-/* 옵션 섹션 헤더 스타일 */
-.options-section h2 { margin-bottom: 8px; color: #2c3e50; }
-.desc { color: #666; margin-bottom: 24px; }
-.empty-options { color: #888; text-align: center; padding: 20px; }
+.product-info-section {
+  text-align: center;
+  margin-bottom: 30px;
+}
+
+.bank-badge {
+  background: #e3f2fd;
+  color: #1565c0;
+  padding: 6px 12px;
+  border-radius: 20px;
+  font-weight: bold;
+  font-size: 0.9rem;
+}
+
+.type-badge {
+  display: inline-block;
+  padding: 6px 12px;
+  border-radius: 20px;
+  font-size: 0.8rem;
+  font-weight: 600;
+}
+
+.type-badge.DEPOSIT {
+  background-color: #e3f2fd;
+  color: #1565c0;
+}
+
+.type-badge.SAVING {
+  background-color: #f3e5f5;
+  color: #7b1fa2;
+}
+
+.title {
+  font-size: 2rem;
+  margin: 16px 0 30px;
+  color: #333;
+}
+
+.info-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 20px;
+  background: #f8f9fa;
+  padding: 24px;
+  border-radius: 16px;
+  text-align: left;
+}
+
+.info-item h4 {
+  font-size: 0.9rem;
+  color: #666;
+  margin-bottom: 8px;
+}
+
+.info-item p {
+  font-size: 1rem;
+  color: #333;
+  line-height: 1.5;
+}
+
+.full-width {
+  grid-column: 1 / -1;
+}
+
+.divider {
+  border: 0;
+  height: 1px;
+  background: #eee;
+  margin: 40px 0;
+}
+
+.options-section h2 {
+  margin-bottom: 8px;
+  color: #2c3e50;
+}
+
+.desc {
+  color: #666;
+  margin-bottom: 24px;
+}
+
+.empty-options {
+  color: #888;
+  text-align: center;
+  padding: 20px;
+}
 </style>

--- a/frontend/src/views/user/MyPageView.vue
+++ b/frontend/src/views/user/MyPageView.vue
@@ -61,7 +61,8 @@
 </template>
 
 <script setup>
-import { ref, computed, onMounted } from 'vue'
+import { ref, computed, onMounted, watch } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
 import { useAccountStore } from '@/stores/accounts'
 
 import UserProfileSection from '@/components/user/UserProfileSection.vue'
@@ -71,25 +72,44 @@ import RateChart from '@/components/product/RateChart.vue'
 import MoathonCard from '@/components/moathon/MoathonCard.vue'
 
 const store = useAccountStore()
+const route = useRoute()
+const router = useRouter()
+
 const user = computed(() => store.user)
 const loading = ref(true)
 const isEditing = ref(false)
+
+watch(
+  () => route.query.edit,
+  (newVal) => {
+    isEditing.value = newVal === 'true'
+  },
+  { immediate: true }
+)
+
 onMounted(async () => {
   try {
+    loading.value = true
     await store.getProfile()
   } catch (err) {
-    console.error(err)
+    console.error('내 정보 로딩 실패:', err)
   } finally {
     loading.value = false
   }
 })
 
 const toggleEdit = () => {
-  isEditing.value = !isEditing.value
+  const nextState = !isEditing.value
+  isEditing.value = nextState
+  router.replace({ 
+    query: { ...route.query, edit: nextState ? 'true' : undefined } 
+  })
 }
 
 const onUpdateSuccess = async () => {
   isEditing.value = false
+  router.replace({ query: { ...route.query, edit: undefined } })
+  await store.getProfile()
 }
 </script>
 


### PR DESCRIPTION
## 💡 개요 (Overview)
서비스의 전역 권한 정책을 재수립하고, 비로그인 사용자가 상세 페이지나 추천 기능에 접근할 때 발생하는 UX 문제(무한 로딩, 동작 없음 등)를 해결했습니다.

## 📃 작업 내용 (Details)
### Backend
- **`settings.py`**: 전역 권한 클래스를 `AllowAny`에서 `IsAuthenticatedOrReadOnly`로 변경하여, 비로그인 사용자도 조회(GET)는 가능하되 쓰기/수정(POST/PUT)은 불가능하도록 보안을 강화했습니다.

### Frontend
- **`ProductDetailView.vue`**: 
  - `watch`와 `isLoading` 상태를 도입하여, 권한 없음(401) 에러 발생 시 무한 로딩에 빠지지 않고 에러 화면이 표시되도록 수정했습니다.
  - '이 옵션으로 시작하기' 버튼 클릭 시 비로그인 상태라면 로그인 페이지로 이동하도록 가드 로직을 추가했습니다.
- **`MoathonDetailView.vue`**: 
  - 비로그인 사용자가 접근 시 데이터를 불러오지 못해 화면이 멈추는 현상을 수정했습니다.
- **`HomeView.vue`**: 
  - '내 맞춤 모아톤 시작하기' 버튼 클릭 시, 사용자 상태(비로그인 / 정보 누락 / 정상)에 따라 적절한 페이지(로그인 / 프로필수정 / 추천)로 분기 처리하는 `handleStartRecommendation` 함수를 구현했습니다.

## 🔗 관련 이슈 (Links)
- Closes #97 


## 📸 스크린샷 (Screenshots)
모아톤 상세 페이지 접근 시, 로그인 페이지로 이동
<img width="1916" height="905" alt="image" src="https://github.com/user-attachments/assets/17d7873c-97aa-4d69-a475-8c93c3a72162" />

비로그인 사용자가 모아톤 생성하려고 할 때, 로그인 페이지로 이동
<img width="1905" height="956" alt="image" src="https://github.com/user-attachments/assets/968325be-f094-4e74-92c6-9abd9ed23ce3" />

비로그인 사용자가 내 맞춤 모아톤 만들기 누르면, 로그인 페이지로 이동
<img width="1909" height="943" alt="image" src="https://github.com/user-attachments/assets/e8f6d9f7-4f5c-454b-a548-e81dd743385c" />


## 📚 테스트 (Test)
- [ ] 로컬 환경에서 기능 테스트 완료
- [ ] 기존 기능에 영향 없는지 확인 완료